### PR TITLE
Fix SHAP Permutation explainer max_evals too low error

### DIFF
--- a/scripts/precompute/shap_analysis.py
+++ b/scripts/precompute/shap_analysis.py
@@ -85,7 +85,8 @@ def main():
         model.predict,
         shap.maskers.Independent(background, max_samples=50),
     )
-    shap_values = explainer(X_shap[:min(200, len(X_shap))]).values
+    max_evals = 2 * X_shap.shape[1] + 1
+    shap_values = explainer(X_shap[:min(200, len(X_shap))], max_evals=max_evals).values
     
     # Get feature names
     feature_names = preprocessor.get_feature_names_out()


### PR DESCRIPTION
This pull request updates the SHAP analysis script to improve how SHAP values are computed. The main change is to set the `max_evals` parameter dynamically based on the number of features, which can lead to more accurate and efficient SHAP value estimation.

**SHAP analysis improvements:**

* In `scripts/precompute/shap_analysis.py`, the call to the SHAP explainer now passes a `max_evals` parameter calculated as `2 * X_shap.shape[1] + 1`, allowing the number of evaluations to scale with the number of features.