### PR TITLE
Fix Streamlit resource usage and precompute diagnostics

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,9 +45,9 @@ Short, actionable guidance for AI coding agents working on the Formula 1 Analysi
   - Weather fetching logic updated to pull data for all missing races, not just the most recent one.
   - Optional post-run smoke checks: pass `--check-smoke` to run `scripts/check_generation_smoke.py` (see helper scripts). Forward `--smoke-strict`, `--smoke-qual-threshold`, and `--smoke-tolerance-days` to control behavior.
   - Recent fixes batch high-cardinality bin creation to reduce DataFrame fragmentation and silence PerformanceWarnings.
-  - All data loading functions use `@st.cache_data` decorator for performance.
-  - Uses CACHE_VERSION="v2.3" for version-based cache invalidation to prevent stale cached models on Streamlit Cloud.
-  - Four prediction models: XGBoost, LightGBM, CatBoost, and Ensemble stacking (XGBoost + LightGBM + CatBoost).
+  - Data loading functions use bounded `@st.cache_data` caches; ML artifacts use bounded `@st.cache_resource` so sessions share one model instance.
+  - Uses `CACHE_VERSION="v3.3"` plus SHA-256 dataset fingerprints for model compatibility. Never use Git checkout mtimes to decide whether a model is current.
+  - Six prediction models: XGBoost, LightGBM, CatBoost, Ensemble, Position Group, and Track-Weighted Ensemble.
   - Hyperparameter optimization with Bayesian optimization (Optuna) and grid search.
   - Season-stratified cross-validation to prevent data leakage.
   - Model-specific feature importance extraction and prediction handling.
@@ -144,8 +144,9 @@ Additional preferred practice-best filenames:
 - **Leakage prevention**: All features use `.shift()` or filtering to avoid using future data. Safety car features (line 2224+) are specifically designed to be available before race starts.
  - **Leakage prevention**: All features use `.shift()` or filtering to avoid using future data. Safety car features (line 2224+) are specifically designed to be available before race starts. A temporal leakage audit script (`scripts/audit_temporal_leakage.py`) was added and runs as part of smoke checks to flag suspicious columns; `points_leader_gap` was updated to compute the per-race snapshot leader gap (grouped by `grandPrixYear` + `round`/`raceId`/`short_date`) to avoid season-wide leakage.
 - **Incremental data pulls**: Scripts like `f1-raceMessages.py` track previously processed sessions and only pull new data to avoid API rate limits and reduce runtime.
-- **Streamlit caching**: All heavy data operations use `@st.cache_data` to avoid recomputation on every widget interaction.
-- **Cache invalidation**: Uses CACHE_VERSION system for all cached functions to prevent feature shape mismatches on Streamlit Cloud deployments.
+- **Streamlit caching**: Use bounded `@st.cache_data` for serializable data and bounded `@st.cache_resource` for shared, thread-safe ML artifacts. Do not put models in `st.cache_data` or mutate globally shared models during prediction.
+- **Cache invalidation**: Use `CACHE_VERSION` for code/schema compatibility and the SHA-256 helpers in `model_artifacts.py` for dataset compatibility. Filesystem mtimes may be used only to invalidate fingerprint/model-loading caches, never to determine artifact freshness.
+- **No request-time training**: Production page loads must use GitHub-workflow-generated artifacts. If an artifact is temporarily stale, serve the latest precomputed model with a freshness warning; do not train in Streamlit Community Cloud.
 
 ## External integrations
 - **F1DB**: Source JSON files from github.com/f1db/f1db (all `f1db-*.json` files in `data_files/`)
@@ -373,16 +374,16 @@ Practical tips / QC checks
   ```
 - **Cache invalidation pattern**:
   ```python
-  # Always include CACHE_VERSION in cached functions to prevent stale models
-  @st.cache_data
-  def load_and_preprocess_data(CACHE_VERSION):
+  # Include CACHE_VERSION and the stable data digest in bounded data caches.
+  @st.cache_data(max_entries=1)
+  def load_and_preprocess_data(CACHE_VERSION, data_sha256):
       # Data loading and preprocessing logic
       return processed_data
-  
-  @st.cache_data  
-  def train_model(X, y, model_type, CACHE_VERSION):
-      # Model training logic
-      return trained_model
+
+  # Workflow-generated ML objects are shared resources, not copied data.
+  @st.cache_resource(max_entries=8)
+  def load_model(model_type, CACHE_VERSION, data_sha256, artifact_signature):
+      return load_precomputed_artifact(model_type)
   ```
 - **Model-specific prediction handling**:
   ```python

--- a/.github/workflows/feature-selection-suite.yml
+++ b/.github/workflows/feature-selection-suite.yml
@@ -83,8 +83,27 @@ jobs:
           name: permutation-results
           path: data_files/precomputed/permutation_results.json
 
+  historical-validation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -r requirements.txt
+      - name: Run Historical Validation
+        run: python scripts/precompute/historical_validation.py --output data_files/precomputed/historical_validation.json
+        env:
+          STREAMLIT_SERVER_HEADLESS: '1'
+      - uses: actions/upload-artifact@v6
+        with:
+          name: historical-validation-results
+          path: data_files/precomputed/historical_validation.json
+
   commit-all:
-    needs: [rfe-selection, boruta-selection, shap-analysis, permutation-importance]
+    needs: [rfe-selection, boruta-selection, shap-analysis, permutation-importance, historical-validation]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/streamlit-api-compat.yml
+++ b/.github/workflows/streamlit-api-compat.yml
@@ -1,0 +1,31 @@
+name: Streamlit API Compatibility
+
+on:
+  pull_request:
+    paths:
+      - '*.py'
+      - '**/*.py'
+      - '.github/workflows/streamlit-api-compat.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - '*.py'
+      - '**/*.py'
+      - '.github/workflows/streamlit-api-compat.yml'
+
+jobs:
+  deprecated-api-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Reject deprecated Streamlit keywords
+        run: python scripts/check_streamlit_deprecations.py
+
+      - name: Test model artifact and runtime cache policy
+        run: python -m unittest discover -s tests

--- a/data_files/precomputed/historical_validation.json
+++ b/data_files/precomputed/historical_validation.json
@@ -1,0 +1,5581 @@
+{
+  "metadata": {
+    "generated_at": "2026-08-09T20:31:01.653652+00:00",
+    "model_type": "XGBoost",
+    "folds": 5,
+    "data_fingerprint": {
+      "data_file": "f1ForAnalysis.csv",
+      "data_sha256": "b69d1f7842a227dcf5c235447f8191fb0992e73d4a37ff5775397418ab93abb3",
+      "data_size": 19581361,
+      "fingerprint_algorithm": "sha256"
+    }
+  },
+  "position_cv": {
+    "mse_mean": 12.206355148094934,
+    "mse_std": 3.90356654598619,
+    "sample_count": 3951
+  },
+  "dnf_validation": {
+    "test_mae": 0.27224032909395113,
+    "roc_auc_mean": 0.4910038213827067,
+    "roc_auc_std": 0.053915614400445636,
+    "sample_count": 4563
+  },
+  "safety_car_validation": {
+    "roc_auc_mean": 0.890699964079755,
+    "roc_auc_std": 0.01108138798204415,
+    "sample_count": 4563
+  },
+  "holdout": {
+    "metrics": {
+      "mse": 4.069125425568581,
+      "r2": 0.8521968571026988,
+      "mae": 1.428767073998409,
+      "mean_error": -0.12764222303925815
+    },
+    "position_mae": {
+      "Podium (1-3)": 0.9977030614589123,
+      "Winners": 0.7695442182677132,
+      "Points (1-10)": 1.2965211108619092
+    },
+    "rows": [
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 13.596098899841309,
+        "Error": -3.5960988998413086
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.610719680786133,
+        "Error": -1.6107196807861328
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 12.959680557250977,
+        "Error": 3.0403194427490234
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 14.822983741760254,
+        "Error": 3.177016258239746
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.186286926269531,
+        "Error": 0.8137130737304688
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 11.665167808532715,
+        "Error": 2.334832191467285
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.3316272497177124,
+        "Error": -0.3316272497177124
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.849883556365967,
+        "Error": 0.1501164436340332
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Nico Rosberg",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.7559529542922974,
+        "Error": -0.7559529542922974
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 2.3277361392974854,
+        "Error": 1.6722638607025146
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.879724502563477,
+        "Error": -1.8797245025634766
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 0.9540210962295532,
+        "Error": -0.9540210962295532
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 9.515423774719238,
+        "Error": -2.5154237747192383
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.109981060028076,
+        "Error": -0.10998106002807617
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.276813507080078,
+        "Error": -1.2768135070800781
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 10.19861888885498,
+        "Error": -1.1986188888549805
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 5.583215236663818,
+        "Error": 3.4167847633361816
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 9.80082893371582,
+        "Error": 1.1991710662841797
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 6.6279683113098145,
+        "Error": 0.37203168869018555
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.242100715637207,
+        "Error": 1.757899284362793
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.4038565158843994,
+        "Error": -0.4038565158843994
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.223559379577637,
+        "Error": 0.7764406204223633
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.317420959472656,
+        "Error": 0.6825790405273438
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.8716871738433838,
+        "Error": -0.8716871738433838
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.598262786865234,
+        "Error": -0.5982627868652344
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.828561544418335,
+        "Error": -0.828561544418335
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.748973846435547,
+        "Error": -0.7489738464355469
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.1318401098251343,
+        "Error": -0.13184010982513428
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 14.70356559753418,
+        "Error": 4.29643440246582
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.418728828430176,
+        "Error": 2.581271171569824
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.1530323028564453,
+        "Error": -1.1530323028564453
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 9.34106731414795,
+        "Error": -3.341067314147949
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.984350204467773,
+        "Error": 2.0156497955322266
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.159293174743652,
+        "Error": -0.15929317474365234
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.1438913345336914,
+        "Error": -0.1438913345336914
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 11.295087814331055,
+        "Error": 1.7049121856689453
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 9.7513427734375,
+        "Error": 4.2486572265625
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 5.389777183532715,
+        "Error": 1.6102228164672852
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 14.829212188720703,
+        "Error": -1.8292121887207031
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.114392280578613,
+        "Error": -1.1143922805786133
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 16.200210571289062,
+        "Error": 1.7997894287109375
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.5720791816711426,
+        "Error": -0.5720791816711426
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.666221618652344,
+        "Error": -0.6662216186523438
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.944758176803589,
+        "Error": -0.9447581768035889
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.236096382141113,
+        "Error": -0.23609638214111328
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.405648708343506,
+        "Error": 0.5943512916564941
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.1438441276550293,
+        "Error": -0.1438441276550293
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.512018203735352,
+        "Error": 0.48798179626464844
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.977104187011719,
+        "Error": -0.9771041870117188
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.184877395629883,
+        "Error": -1.1848773956298828
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 12.446659088134766,
+        "Error": -2.4466590881347656
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 12.412186622619629,
+        "Error": -3.412186622619629
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.575777053833008,
+        "Error": -1.5757770538330078
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 10.732755661010742,
+        "Error": 3.267244338989258
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 4.659660816192627,
+        "Error": -1.659660816192627
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Stoffel Vandoorne",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.09620475769043,
+        "Error": 0.9037952423095703
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.490332841873169,
+        "Error": 0.509667158126831
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.0631150007247925,
+        "Error": -0.06311500072479248
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.013294219970703,
+        "Error": -2.013294219970703
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.280815124511719,
+        "Error": -2.2808151245117188
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.3431801795959473,
+        "Error": 0.6568198204040527
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 15.444518089294434,
+        "Error": -1.4445180892944336
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.870832085609436,
+        "Error": -0.870832085609436
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.511655807495117,
+        "Error": 0.4883441925048828
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.47362995147705,
+        "Error": 0.5263700485229492
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.630929946899414,
+        "Error": -1.630929946899414
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 4.992913722991943,
+        "Error": 2.0070862770080566
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.9699019193649292,
+        "Error": -0.9699019193649292
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 2.939720630645752,
+        "Error": 1.060279369354248
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 9.065152168273926,
+        "Error": 1.9348478317260742
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 15.816067695617676,
+        "Error": 3.183932304382324
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 7.168478488922119,
+        "Error": -7.168478488922119
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.244694471359253,
+        "Error": -1.244694471359253
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 9.788719177246094,
+        "Error": 1.2112808227539062
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 16.018848419189453,
+        "Error": 2.981151580810547
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 6.598653793334961,
+        "Error": 1.401346206665039
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.4789211750030518,
+        "Error": 0.5210788249969482
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 14.357462882995605,
+        "Error": 5.6425371170043945
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 13.340517044067383,
+        "Error": -2.340517044067383
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.421236991882324,
+        "Error": -1.4212369918823242
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 12.96025276184082,
+        "Error": 2.0397472381591797
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.916759490966797,
+        "Error": 1.0832405090332031
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 7.718865394592285,
+        "Error": -2.718865394592285
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.123036861419678,
+        "Error": -1.1230368614196777
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.4616265296936035,
+        "Error": -1.4616265296936035
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.4255330562591553,
+        "Error": -0.4255330562591553
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.320685386657715,
+        "Error": -1.3206853866577148
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.93220329284668,
+        "Error": -2.9322032928466797
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.826059579849243,
+        "Error": 0.17394042015075684
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 14.421518325805664,
+        "Error": -3.421518325805664
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.946434497833252,
+        "Error": -1.946434497833252
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 4.7988786697387695,
+        "Error": -1.7988786697387695
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 7.895381450653076,
+        "Error": 1.1046185493469238
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 3.693361759185791,
+        "Error": -2.693361759185791
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.996642112731934,
+        "Error": 2.0033578872680664
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.714189529418945,
+        "Error": 0.2858104705810547
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.207195281982422,
+        "Error": -0.20719528198242188
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 9.339717864990234,
+        "Error": 5.660282135009766
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Stoffel Vandoorne",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.226840019226074,
+        "Error": -2.226840019226074
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.312676429748535,
+        "Error": -1.3126764297485352
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 7.380615711212158,
+        "Error": -2.380615711212158
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.867951393127441,
+        "Error": -1.8679513931274414
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.0016160011291504,
+        "Error": -1.0016160011291504
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.868971824645996,
+        "Error": 2.131028175354004
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 7.670915126800537,
+        "Error": 1.329084873199463
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.260826349258423,
+        "Error": 0.7391736507415771
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 4.064393997192383,
+        "Error": 1.9356060028076172
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.91044807434082,
+        "Error": 1.0895519256591797
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.917305946350098,
+        "Error": -1.9173059463500977
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 8.607650756835938,
+        "Error": 1.3923492431640625
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.122498035430908,
+        "Error": 0.8775019645690918
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 9.738384246826172,
+        "Error": -2.738384246826172
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 2.8410804271698,
+        "Error": 1.1589195728302002
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.159669876098633,
+        "Error": -1.1596698760986328
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.4878665208816528,
+        "Error": -0.48786652088165283
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.37967300415039,
+        "Error": 0.6203269958496094
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Arvid Lindblad",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.655732154846191,
+        "Error": 0.3442678451538086
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 2.386143684387207,
+        "Error": 5.613856315612793
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 1.4849717617034912,
+        "Error": 1.5150282382965088
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.738244533538818,
+        "Error": -0.7382445335388184
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 6.4593048095703125,
+        "Error": 0.5406951904296875
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.942007064819336,
+        "Error": 0.05799293518066406
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.51410484313965,
+        "Error": 0.48589515686035156
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.7368316650390625,
+        "Error": -0.7368316650390625
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Sergey Sirotkin",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.471391677856445,
+        "Error": -0.4713916778564453
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.408140182495117,
+        "Error": -0.4081401824951172
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 12.683843612670898,
+        "Error": 1.3161563873291016
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.647134304046631,
+        "Error": -0.6471343040466309
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 17.61231231689453,
+        "Error": -0.6123123168945312
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 16.04906463623047,
+        "Error": 1.9509353637695312
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 16.42355728149414,
+        "Error": 3.5764427185058594
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 10.999395370483398,
+        "Error": -1.9993953704833984
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.450937747955322,
+        "Error": -0.45093774795532227
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.564035415649414,
+        "Error": 0.43596458435058594
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.764142990112305,
+        "Error": -0.7641429901123047
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 4.348340034484863,
+        "Error": 1.6516599655151367
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.955877304077148,
+        "Error": 0.04412269592285156
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 12.649072647094727,
+        "Error": 2.3509273529052734
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.818583488464355,
+        "Error": -0.8185834884643555
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.378971099853516,
+        "Error": 1.6210289001464844
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.9859628677368164,
+        "Error": -0.9859628677368164
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.265486717224121,
+        "Error": 1.734513282775879
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.455092430114746,
+        "Error": 0.5449075698852539
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.420066833496094,
+        "Error": -1.4200668334960938
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.730700492858887,
+        "Error": -0.7307004928588867
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.609835624694824,
+        "Error": 0.3901643753051758
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 14.341591835021973,
+        "Error": -2.3415918350219727
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.66496753692627,
+        "Error": 0.33503246307373047
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 11.999227523803711,
+        "Error": 1.000772476196289
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.5588836669921875,
+        "Error": -0.5588836669921875
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 5.81453275680542,
+        "Error": 1.18546724319458
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 14.256378173828125,
+        "Error": -1.256378173828125
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.935397148132324,
+        "Error": 0.06460285186767578
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.566109657287598,
+        "Error": 1.4338903427124023
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.5842719078063965,
+        "Error": -0.5842719078063965
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.259312629699707,
+        "Error": 2.740687370300293
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Liam Lawson",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 8.858119010925293,
+        "Error": -0.858119010925293
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.291215896606445,
+        "Error": 0.7087841033935547
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.56072473526001,
+        "Error": 0.43927526473999023
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 7.335136890411377,
+        "Error": -2.335136890411377
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Stoffel Vandoorne",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.582498550415039,
+        "Error": 0.41750144958496094
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.242644309997559,
+        "Error": -1.2426443099975586
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 12.44801139831543,
+        "Error": -5.44801139831543
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.14105224609375,
+        "Error": -0.14105224609375
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.522065162658691,
+        "Error": 1.4779348373413086
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.341078758239746,
+        "Error": 0.6589212417602539
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.371598243713379,
+        "Error": -1.371598243713379
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.4363253116607666,
+        "Error": -0.4363253116607666
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.510882377624512,
+        "Error": -0.5108823776245117
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 7.527771949768066,
+        "Error": -3.5277719497680664
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.0721864700317383,
+        "Error": -0.07218647003173828
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 11.73095989227295,
+        "Error": 4.269040107727051
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.1131489276885986,
+        "Error": -0.11314892768859863
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.6883184909820557,
+        "Error": 0.31168150901794434
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 17.131580352783203,
+        "Error": -4.131580352783203
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.312880516052246,
+        "Error": -1.312880516052246
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.920316696166992,
+        "Error": 1.0796833038330078
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.149469375610352,
+        "Error": -1.1494693756103516
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.709078788757324,
+        "Error": 1.2909212112426758
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Kimi Antonelli",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.58000659942627,
+        "Error": -0.5800065994262695
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.258095741271973,
+        "Error": -1.2580957412719727
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.6244213581085205,
+        "Error": -0.6244213581085205
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 3.5023319721221924,
+        "Error": -3.5023319721221924
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.7722086906433105,
+        "Error": -1.7722086906433105
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.042773246765137,
+        "Error": -2.0427732467651367
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.441864013671875,
+        "Error": 1.558135986328125
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.929800033569336,
+        "Error": 0.07019996643066406
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.095192909240723,
+        "Error": 0.9048070907592773
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 9.500054359436035,
+        "Error": 3.499945640563965
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.414058685302734,
+        "Error": 0.5859413146972656
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.38782024383545,
+        "Error": 1.6121797561645508
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.187236785888672,
+        "Error": -0.18723678588867188
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 10.043737411499023,
+        "Error": -3.0437374114990234
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.204146385192871,
+        "Error": 0.7958536148071289
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.68289852142334,
+        "Error": -0.6828985214233398
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.674180030822754,
+        "Error": -0.6741800308227539
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.026564598083496,
+        "Error": -1.026564598083496
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 12.635299682617188,
+        "Error": -2.6352996826171875
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 8.329367637634277,
+        "Error": -0.32936763763427734
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 3.229783058166504,
+        "Error": -3.229783058166504
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.589505195617676,
+        "Error": -0.5895051956176758
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.501193046569824,
+        "Error": -0.5011930465698242
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 14.426887512207031,
+        "Error": -2.4268875122070312
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.3227139711380005,
+        "Error": -0.3227139711380005
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 9.402945518493652,
+        "Error": 1.5970544815063477
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.415851593017578,
+        "Error": 2.584148406982422
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.547553062438965,
+        "Error": 0.45244693756103516
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.8614003658294678,
+        "Error": -0.8614003658294678
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.1839677095413208,
+        "Error": 0.8160322904586792
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.281877517700195,
+        "Error": 0.7181224822998047
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.887810230255127,
+        "Error": -0.887810230255127
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 15.298064231872559,
+        "Error": -2.2980642318725586
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Robert Kubica",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 18.233131408691406,
+        "Error": -0.23313140869140625
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.60599422454834,
+        "Error": -1.6059942245483398
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.091182708740234,
+        "Error": 0.9088172912597656
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.8368306159973145,
+        "Error": 0.16316938400268555
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.8004755973815918,
+        "Error": -0.8004755973815918
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Robert Kubica",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.635359764099121,
+        "Error": 1.364640235900879
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 4.225449085235596,
+        "Error": 0.7745509147644043
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Robert Kubica",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.941231727600098,
+        "Error": 0.058768272399902344
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.7015187740325928,
+        "Error": -0.7015187740325928
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 1.57289719581604,
+        "Error": -1.57289719581604
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.639870643615723,
+        "Error": 1.3601293563842773
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 14.5712308883667,
+        "Error": -3.571230888366699
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 6.75799560546875,
+        "Error": 0.24200439453125
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.327550172805786,
+        "Error": -1.3275501728057861
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 6.042896747589111,
+        "Error": -2.0428967475891113
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.963702201843262,
+        "Error": 0.03629779815673828
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.4140589237213135,
+        "Error": -0.4140589237213135
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 13.467926979064941,
+        "Error": -3.4679269790649414
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.939990520477295,
+        "Error": -0.9399905204772949
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.059222459793091,
+        "Error": 0.9407775402069092
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.9477386474609375,
+        "Error": -1.9477386474609375
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.291769504547119,
+        "Error": 0.7082304954528809
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.58324146270752,
+        "Error": 0.41675853729248047
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.834190368652344,
+        "Error": 0.16580963134765625
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.937137126922607,
+        "Error": -0.9371371269226074
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.90924334526062,
+        "Error": -0.9092433452606201
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.254340171813965,
+        "Error": 1.7456598281860352
+      },
+      {
+        "constructorName": "Audi",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 7.303473949432373,
+        "Error": -7.303473949432373
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.8120307922363281,
+        "Error": -0.8120307922363281
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Brendon Hartley",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.386857032775879,
+        "Error": -2.386857032775879
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 13.414411544799805,
+        "Error": -2.4144115447998047
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.716941833496094,
+        "Error": 0.28305816650390625
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.492075443267822,
+        "Error": 0.5079245567321777
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Felipe Nasr",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.811416625976562,
+        "Error": 0.1885833740234375
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 6.493277072906494,
+        "Error": 8.506722927093506
+      },
+      {
+        "constructorName": "Audi",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.190308570861816,
+        "Error": 0.8096914291381836
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.498614311218262,
+        "Error": 0.5013856887817383
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.17298412322998,
+        "Error": -0.17298412322998047
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 8.600025177001953,
+        "Error": 4.399974822998047
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 12.881904602050781,
+        "Error": 3.1180953979492188
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 13.162503242492676,
+        "Error": 4.837496757507324
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 16.903776168823242,
+        "Error": -2.903776168823242
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 4.927525043487549,
+        "Error": 1.0724749565124512
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 9.838399887084961,
+        "Error": 3.161600112915039
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.68714714050293,
+        "Error": 0.3128528594970703
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 21.0,
+        "PredictedFinalPosition": 18.228614807128906,
+        "Error": 2.7713851928710938
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 9.78321647644043,
+        "Error": 4.21678352355957
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.295008659362793,
+        "Error": 0.704991340637207
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 11.133271217346191,
+        "Error": 1.8667287826538086
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 12.764952659606934,
+        "Error": -3.7649526596069336
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Nyck de Vries",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.559343338012695,
+        "Error": 0.4406566619873047
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.397895812988281,
+        "Error": -0.39789581298828125
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 13.910161018371582,
+        "Error": 2.089838981628418
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.51945972442627,
+        "Error": -0.5194597244262695
+      },
+      {
+        "constructorName": "RB",
+        "resultsDriverName": "Liam Lawson",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.903227806091309,
+        "Error": 0.0967721939086914
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 11.597488403320312,
+        "Error": 1.4025115966796875
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 11.89116382598877,
+        "Error": -3.8911638259887695
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 16.537755966186523,
+        "Error": 3.4622440338134766
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.9644314050674438,
+        "Error": -0.9644314050674438
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.2914814949035645,
+        "Error": -0.29148149490356445
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.420116424560547,
+        "Error": -0.4201164245605469
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.668161392211914,
+        "Error": -0.6681613922119141
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.707475662231445,
+        "Error": -0.7074756622314453
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.394643783569336,
+        "Error": -1.394643783569336
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 6.325473308563232,
+        "Error": -6.325473308563232
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.225008010864258,
+        "Error": 1.7749919891357422
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.074208736419678,
+        "Error": -1.0742087364196777
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.595421314239502,
+        "Error": -0.595421314239502
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.173637390136719,
+        "Error": -0.17363739013671875
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 12.46934700012207,
+        "Error": 3.5306529998779297
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.1301252841949463,
+        "Error": -1.1301252841949463
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.028069496154785,
+        "Error": 0.9719305038452148
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 10.497477531433105,
+        "Error": -1.4974775314331055
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.606571197509766,
+        "Error": -2.6065711975097656
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Stoffel Vandoorne",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 10.423187255859375,
+        "Error": -1.423187255859375
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.405095100402832,
+        "Error": -0.40509510040283203
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.093282699584961,
+        "Error": -1.093282699584961
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 10.927583694458008,
+        "Error": 4.072416305541992
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 9.663472175598145,
+        "Error": 1.3365278244018555
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.595356941223145,
+        "Error": 0.40464305877685547
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 16.529586791992188,
+        "Error": -1.5295867919921875
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.507282257080078,
+        "Error": 0.4927177429199219
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.91700553894043,
+        "Error": -1.9170055389404297
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 6.99298095703125,
+        "Error": 3.00701904296875
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.016507625579834,
+        "Error": -0.016507625579833984
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.518223285675049,
+        "Error": 0.48177671432495117
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.60364818572998,
+        "Error": -0.6036481857299805
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.376075744628906,
+        "Error": -0.37607574462890625
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 3.944204092025757,
+        "Error": 1.0557959079742432
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.4427690505981445,
+        "Error": -1.4427690505981445
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.188798904418945,
+        "Error": -1.1887989044189453
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.062847137451172,
+        "Error": 0.9371528625488281
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.007248878479004,
+        "Error": -0.007248878479003906
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.922831058502197,
+        "Error": -0.9228310585021973
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 7.71021032333374,
+        "Error": -2.7102103233337402
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.303207397460938,
+        "Error": -1.3032073974609375
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 1.9755115509033203,
+        "Error": 1.0244884490966797
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.240045547485352,
+        "Error": -1.2400455474853516
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.2573986053466797,
+        "Error": 0.7426013946533203
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.955721855163574,
+        "Error": -0.9557218551635742
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 15.421758651733398,
+        "Error": -2.4217586517333984
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.290148138999939,
+        "Error": -0.29014813899993896
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 11.27783489227295,
+        "Error": -4.277834892272949
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 4.807426929473877,
+        "Error": 1.192573070526123
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 13.622904777526855,
+        "Error": -3.6229047775268555
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.2372357845306396,
+        "Error": -1.2372357845306396
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 17.13376808166504,
+        "Error": -1.133768081665039
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Jenson Button",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.804828643798828,
+        "Error": 0.19517135620117188
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.9360008239746094,
+        "Error": 0.06399917602539062
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.657393455505371,
+        "Error": -1.657393455505371
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 10.24380111694336,
+        "Error": -3.2438011169433594
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.965640068054199,
+        "Error": -0.9656400680541992
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 7.580352783203125,
+        "Error": 2.419647216796875
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.6988134384155273,
+        "Error": -0.6988134384155273
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.795844078063965,
+        "Error": 0.20415592193603516
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 13.548584938049316,
+        "Error": -2.5485849380493164
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.520532131195068,
+        "Error": 0.47946786880493164
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 16.546342849731445,
+        "Error": -3.5463428497314453
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.340478897094727,
+        "Error": 1.6595211029052734
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 10.215286254882812,
+        "Error": -4.2152862548828125
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 8.566385269165039,
+        "Error": 1.433614730834961
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 15.655317306518555,
+        "Error": -4.655317306518555
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.26543664932251,
+        "Error": -1.2654366493225098
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.814937591552734,
+        "Error": 2.1850624084472656
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.8071415424346924,
+        "Error": -1.8071415424346924
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.182138442993164,
+        "Error": 0.8178615570068359
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.520572662353516,
+        "Error": -1.5205726623535156
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 15.599503517150879,
+        "Error": 2.400496482849121
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 4.1075663566589355,
+        "Error": 2.8924336433410645
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.005776405334473,
+        "Error": -2.0057764053344727
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 13.50045394897461,
+        "Error": 2.4995460510253906
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 17.196247100830078,
+        "Error": 1.8037528991699219
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.1913106441497803,
+        "Error": -0.19131064414978027
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 16.685340881347656,
+        "Error": 2.3146591186523438
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.607293128967285,
+        "Error": 2.392706871032715
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.1550754308700562,
+        "Error": -0.15507543087005615
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.517486095428467,
+        "Error": -0.5174860954284668
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.947638511657715,
+        "Error": 0.052361488342285156
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.799159049987793,
+        "Error": -1.799159049987793
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 16.135406494140625,
+        "Error": -6.135406494140625
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 11.43237018585205,
+        "Error": 3.567629814147949
+      },
+      {
+        "constructorName": "RB",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.129685401916504,
+        "Error": 1.870314598083496
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 9.975167274475098,
+        "Error": -2.9751672744750977
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.5444118976593018,
+        "Error": 0.45558810234069824
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.30317211151123,
+        "Error": 0.6968278884887695
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 14.675918579101562,
+        "Error": -1.6759185791015625
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.516562581062317,
+        "Error": 0.4834374189376831
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.489044666290283,
+        "Error": 0.5109553337097168
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.27683162689209,
+        "Error": 0.7231683731079102
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.447550773620605,
+        "Error": 2.5524492263793945
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.730125427246094,
+        "Error": -2.7301254272460938
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.973943710327148,
+        "Error": 1.0260562896728516
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.729578018188477,
+        "Error": 0.27042198181152344
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 15.433369636535645,
+        "Error": 2.5666303634643555
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 4.530221462249756,
+        "Error": 0.46977853775024414
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.700448513031006,
+        "Error": -0.7004485130310059
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 16.337509155273438,
+        "Error": -4.3375091552734375
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.397511005401611,
+        "Error": -0.39751100540161133
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 15.552250862121582,
+        "Error": 2.447749137878418
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.528709411621094,
+        "Error": 0.47129058837890625
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.170296669006348,
+        "Error": 0.8297033309936523
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Robert Kubica",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.73813819885254,
+        "Error": 0.26186180114746094
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.212109565734863,
+        "Error": -0.21210956573486328
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.590582847595215,
+        "Error": 1.4094171524047852
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.06328010559082,
+        "Error": 0.9367198944091797
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 15.714746475219727,
+        "Error": -3.7147464752197266
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.686634063720703,
+        "Error": 0.3133659362792969
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.39171028137207,
+        "Error": -1.3917102813720703
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.262391090393066,
+        "Error": -0.2623910903930664
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 10.266031265258789,
+        "Error": -1.266031265258789
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Stoffel Vandoorne",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.055553436279297,
+        "Error": 0.9444465637207031
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.684122085571289,
+        "Error": -2.684122085571289
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 10.271147727966309,
+        "Error": -4.271147727966309
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.209805965423584,
+        "Error": -1.209805965423584
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 8.385302543640137,
+        "Error": -0.3853025436401367
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.53365421295166,
+        "Error": -2.53365421295166
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.891819953918457,
+        "Error": 0.10818004608154297
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.46871018409729,
+        "Error": -0.46871018409729004
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.950235366821289,
+        "Error": -0.9502353668212891
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.554544448852539,
+        "Error": 0.44545555114746094
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.509340286254883,
+        "Error": 0.4906597137451172
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.840354919433594,
+        "Error": -0.8403549194335938
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.9582504034042358,
+        "Error": 0.04174959659576416
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 9.864877700805664,
+        "Error": 5.135122299194336
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.392549514770508,
+        "Error": 0.6074504852294922
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.5244333744049072,
+        "Error": 0.4755666255950928
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 16.143260955810547,
+        "Error": 2.856739044189453
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.465930223464966,
+        "Error": 0.5340697765350342
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.962733268737793,
+        "Error": 0.03726673126220703
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.095841407775879,
+        "Error": 0.9041585922241211
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.531868934631348,
+        "Error": -0.5318689346313477
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Jenson Button",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.237780570983887,
+        "Error": -0.23778057098388672
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.2797671556472778,
+        "Error": -0.27976715564727783
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.362201690673828,
+        "Error": -2.362201690673828
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.820605754852295,
+        "Error": 0.17939424514770508
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Nico Rosberg",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.4336332082748413,
+        "Error": -0.4336332082748413
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Robert Kubica",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 18.581968307495117,
+        "Error": 1.4180316925048828
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.642261505126953,
+        "Error": -1.6422615051269531
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.505889892578125,
+        "Error": -1.505889892578125
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Guti\u00e9rrez",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.822819709777832,
+        "Error": 0.17718029022216797
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 6.899982929229736,
+        "Error": 1.1000170707702637
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.8625335693359375,
+        "Error": 0.1374664306640625
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.487020015716553,
+        "Error": -1.4870200157165527
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.529946327209473,
+        "Error": -1.5299463272094727
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Jenson Button",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.26782512664795,
+        "Error": 0.7321748733520508
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 15.206114768981934,
+        "Error": -0.2061147689819336
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.396230697631836,
+        "Error": -1.396230697631836
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 9.371916770935059,
+        "Error": 1.6280832290649414
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 18.881511688232422,
+        "Error": 1.1184883117675781
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.945890426635742,
+        "Error": -0.9458904266357422
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Sergey Sirotkin",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.465295791625977,
+        "Error": 0.5347042083740234
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.495446681976318,
+        "Error": -1.4954466819763184
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.209712505340576,
+        "Error": -1.2097125053405762
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 6.4024739265441895,
+        "Error": -2.4024739265441895
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.567460536956787,
+        "Error": -1.567460536956787
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.260706901550293,
+        "Error": -0.26070690155029297
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.138208389282227,
+        "Error": 0.8617916107177734
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.165328979492188,
+        "Error": -1.1653289794921875
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.377236366271973,
+        "Error": 0.6227636337280273
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 13.689558029174805,
+        "Error": -4.689558029174805
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.42018985748291,
+        "Error": 0.5798101425170898
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.870899200439453,
+        "Error": -1.8708992004394531
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Nyck de Vries",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.058100700378418,
+        "Error": 0.941899299621582
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.270245313644409,
+        "Error": -0.2702453136444092
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.133448600769043,
+        "Error": 0.866551399230957
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Nico Rosberg",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.250004768371582,
+        "Error": -0.25000476837158203
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.11524772644043,
+        "Error": 0.8847522735595703
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.299108982086182,
+        "Error": -0.29910898208618164
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.816678047180176,
+        "Error": 0.18332195281982422
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.40051794052124,
+        "Error": -0.40051794052124023
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 11.806310653686523,
+        "Error": 4.193689346313477
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 15.138228416442871,
+        "Error": -1.138228416442871
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.930280685424805,
+        "Error": -1.9302806854248047
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 12.459612846374512,
+        "Error": 5.540387153625488
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.843586921691895,
+        "Error": 0.15641307830810547
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 6.610129356384277,
+        "Error": -2.6101293563842773
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.596783638000488,
+        "Error": 0.4032163619995117
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.246245384216309,
+        "Error": -0.2462453842163086
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.593222141265869,
+        "Error": -0.5932221412658691
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.56074333190918,
+        "Error": -2.5607433319091797
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 14.128008842468262,
+        "Error": -2.1280088424682617
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.465287208557129,
+        "Error": 0.5347127914428711
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.5610785484313965,
+        "Error": -1.5610785484313965
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.630016803741455,
+        "Error": -0.6300168037414551
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.856427192687988,
+        "Error": 0.14357280731201172
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.089946746826172,
+        "Error": -0.08994674682617188
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Rio Haryanto",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 20.153757095336914,
+        "Error": -0.15375709533691406
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.672212600708008,
+        "Error": 1.3277873992919922
+      },
+      {
+        "constructorName": "Audi",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.163810729980469,
+        "Error": 2.8361892700195312
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.0463433265686035,
+        "Error": -0.046343326568603516
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 11.72947883605957,
+        "Error": 2.2705211639404297
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.696937561035156,
+        "Error": 1.3030624389648438
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.393401145935059,
+        "Error": -0.3934011459350586
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.2524665594100952,
+        "Error": -0.2524665594100952
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Brendon Hartley",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 19.28510093688965,
+        "Error": 0.7148990631103516
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 12.709789276123047,
+        "Error": -2.709789276123047
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 7.457864761352539,
+        "Error": 1.542135238647461
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 8.671927452087402,
+        "Error": -2.6719274520874023
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 11.626415252685547,
+        "Error": -4.626415252685547
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.526354789733887,
+        "Error": -0.5263547897338867
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 14.573187828063965,
+        "Error": -2.573187828063965
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Guti\u00e9rrez",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 17.11687660217285,
+        "Error": -1.1168766021728516
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.46692943572998,
+        "Error": -1.4669294357299805
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 19.292030334472656,
+        "Error": 0.7079696655273438
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 7.404987812042236,
+        "Error": -2.4049878120422363
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 4.89666748046875,
+        "Error": 0.10333251953125
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Kimi Antonelli",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.718644618988037,
+        "Error": -0.7186446189880371
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.187239646911621,
+        "Error": -1.187239646911621
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.490939140319824,
+        "Error": -0.4909391403198242
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.743903160095215,
+        "Error": -0.7439031600952148
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.682884931564331,
+        "Error": -0.682884931564331
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.5379475355148315,
+        "Error": -0.5379475355148315
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Stoffel Vandoorne",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.229726791381836,
+        "Error": 0.7702732086181641
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 11.571516036987305,
+        "Error": 2.4284839630126953
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.020183563232422,
+        "Error": -0.020183563232421875
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.878404974937439,
+        "Error": -0.878404974937439
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 9.17580509185791,
+        "Error": -9.17580509185791
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 7.9370198249816895,
+        "Error": 1.0629801750183105
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 4.702450275421143,
+        "Error": 1.2975497245788574
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 5.653789520263672,
+        "Error": -5.653789520263672
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 4.163403511047363,
+        "Error": 15.836596488952637
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.668752670288086,
+        "Error": -1.668752670288086
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 9.505879402160645,
+        "Error": -2.5058794021606445
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.861968040466309,
+        "Error": 0.1380319595336914
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.1873722076416016,
+        "Error": -0.18737220764160156
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Rio Haryanto",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 18.81757926940918,
+        "Error": -0.8175792694091797
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.525390625,
+        "Error": 0.474609375
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.975726127624512,
+        "Error": -1.9757261276245117
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 12.132722854614258,
+        "Error": -2.132722854614258
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.7382824420928955,
+        "Error": -0.7382824420928955
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 14.636208534240723,
+        "Error": -1.6362085342407227
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 5.478926658630371,
+        "Error": 1.521073341369629
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.433692932128906,
+        "Error": -0.43369293212890625
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 6.550195693969727,
+        "Error": 0.44980430603027344
+      },
+      {
+        "constructorName": "RB",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.598862648010254,
+        "Error": 1.401137351989746
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.4051833152770996,
+        "Error": 0.5948166847229004
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 12.7722806930542,
+        "Error": 3.227719306945801
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.84395980834961,
+        "Error": -1.8439598083496094
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.773892879486084,
+        "Error": 0.22610712051391602
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.5395708084106445,
+        "Error": 0.46042919158935547
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.020346641540527,
+        "Error": -2.0203466415405273
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.949835777282715,
+        "Error": -1.9498357772827148
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.123002052307129,
+        "Error": -1.123002052307129
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.613748550415039,
+        "Error": 0.38625144958496094
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 4.057500839233398,
+        "Error": 0.9424991607666016
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.575722694396973,
+        "Error": 1.4242773056030273
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.2681639194488525,
+        "Error": -0.26816391944885254
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.54360008239746,
+        "Error": -0.5436000823974609
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.829495429992676,
+        "Error": -1.8294954299926758
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.098423719406128,
+        "Error": -0.09842371940612793
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 15.567760467529297,
+        "Error": -1.5677604675292969
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.972909927368164,
+        "Error": -0.9729099273681641
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 6.524453163146973,
+        "Error": 1.4755468368530273
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 8.862736701965332,
+        "Error": -2.862736701965332
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.781291961669922,
+        "Error": -1.7812919616699219
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 17.668582916259766,
+        "Error": -0.6685829162597656
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 9.51520824432373,
+        "Error": 4.4847917556762695
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 12.744606018066406,
+        "Error": -5.744606018066406
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 12.55636215209961,
+        "Error": 2.4436378479003906
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 4.833970069885254,
+        "Error": 1.166029930114746
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.482406616210938,
+        "Error": 1.5175933837890625
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.72661018371582,
+        "Error": 0.2733898162841797
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 13.070108413696289,
+        "Error": -5.070108413696289
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.565353870391846,
+        "Error": -1.5653538703918457
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.811553001403809,
+        "Error": 0.1884469985961914
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.2448091506958,
+        "Error": 1.7551908493041992
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.091557025909424,
+        "Error": -0.09155702590942383
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 2.10163950920105,
+        "Error": -2.10163950920105
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.847496271133423,
+        "Error": -0.8474962711334229
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 8.601707458496094,
+        "Error": -0.6017074584960938
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 9.901249885559082,
+        "Error": -2.901249885559082
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.528533458709717,
+        "Error": -0.5285334587097168
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.954181671142578,
+        "Error": 0.045818328857421875
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.466574192047119,
+        "Error": -0.46657419204711914
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.159182548522949,
+        "Error": -1.1591825485229492
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.462377071380615,
+        "Error": 0.5376229286193848
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 11.718425750732422,
+        "Error": 2.281574249267578
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 3.877185106277466,
+        "Error": 1.1228148937225342
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 4.037330627441406,
+        "Error": -2.0373306274414062
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.08802318572998,
+        "Error": -0.08802318572998047
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.13767147064209,
+        "Error": -1.1376714706420898
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Nyck de Vries",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.231011390686035,
+        "Error": -0.23101139068603516
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 20.0,
+        "PredictedFinalPosition": 18.89561653137207,
+        "Error": 1.1043834686279297
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 16.19541358947754,
+        "Error": -2.195413589477539
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 12.50284481048584,
+        "Error": -2.50284481048584
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.377485275268555,
+        "Error": 0.6225147247314453
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 4.465342998504639,
+        "Error": -1.4653429985046387
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 17.05076789855957,
+        "Error": 1.9492321014404297
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.108689308166504,
+        "Error": -0.1086893081665039
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.268255233764648,
+        "Error": -1.2682552337646484
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.568560600280762,
+        "Error": 0.4314393997192383
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 9.697957992553711,
+        "Error": -0.6979579925537109
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.109560251235962,
+        "Error": 0.8904397487640381
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.953310012817383,
+        "Error": 0.04668998718261719
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.262248516082764,
+        "Error": -0.26224851608276367
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.585966110229492,
+        "Error": -1.5859661102294922
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 4.220835208892822,
+        "Error": -2.2208352088928223
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 8.557747840881348,
+        "Error": -0.5577478408813477
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.3717763423919678,
+        "Error": -0.3717763423919678
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 7.287572383880615,
+        "Error": -1.2875723838806152
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.898049354553223,
+        "Error": -1.8980493545532227
+      },
+      {
+        "constructorName": "Manor",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 16.323854446411133,
+        "Error": -1.3238544464111328
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.490486145019531,
+        "Error": -2.4904861450195312
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.08289909362793,
+        "Error": 0.9171009063720703
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.485134243965149,
+        "Error": -0.4851342439651489
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.6737260818481445,
+        "Error": -1.6737260818481445
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 13.053509712219238,
+        "Error": -2.0535097122192383
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.4534239768981934,
+        "Error": 0.5465760231018066
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.438697814941406,
+        "Error": 0.5613021850585938
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.164801597595215,
+        "Error": 0.8351984024047852
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 5.571199893951416,
+        "Error": 2.428800106048584
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.5004305839538574,
+        "Error": -0.5004305839538574
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 13.285192489624023,
+        "Error": -4.285192489624023
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 16.706714630126953,
+        "Error": -1.7067146301269531
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 6.948915481567383,
+        "Error": 0.05108451843261719
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 7.965764999389648,
+        "Error": -2.9657649993896484
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.77855110168457,
+        "Error": 1.2214488983154297
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.0327253341674805,
+        "Error": -1.0327253341674805
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.856122970581055,
+        "Error": -0.8561229705810547
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 8.21868896484375,
+        "Error": -0.21868896484375
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.348850727081299,
+        "Error": -1.3488507270812988
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 3.8312230110168457,
+        "Error": 0.1687769889831543
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 8.195852279663086,
+        "Error": -2.195852279663086
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.36837387084961,
+        "Error": 0.6316261291503906
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 17.73549461364746,
+        "Error": -0.7354946136474609
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.908036231994629,
+        "Error": 0.0919637680053711
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 10.592758178710938,
+        "Error": -2.5927581787109375
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 8.937543869018555,
+        "Error": -2.9375438690185547
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 8.792348861694336,
+        "Error": 2.207651138305664
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 17.993608474731445,
+        "Error": 0.0063915252685546875
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 17.8822078704834,
+        "Error": 1.1177921295166016
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.356819152832031,
+        "Error": -0.35681915283203125
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 17.10995864868164,
+        "Error": 1.8900413513183594
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 14.494988441467285,
+        "Error": 3.505011558532715
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Felipe Nasr",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.55190658569336,
+        "Error": -0.5519065856933594
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 7.451656341552734,
+        "Error": 2.5483436584472656
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 0.6950384378433228,
+        "Error": -0.6950384378433228
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.380307674407959,
+        "Error": -0.380307674407959
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 10.03675365447998,
+        "Error": 3.9632463455200195
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 5.997463703155518,
+        "Error": 1.0025362968444824
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.2300846576690674,
+        "Error": -0.23008465766906738
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 0.0,
+        "PredictedFinalPosition": 0.8499898314476013,
+        "Error": -0.8499898314476013
+      },
+      {
+        "constructorName": "Audi",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.59786605834961,
+        "Error": 0.4021339416503906
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 12.731188774108887,
+        "Error": 1.2688112258911133
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.1449041366577148,
+        "Error": -0.14490413665771484
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.9709293842315674,
+        "Error": -0.9709293842315674
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 10.827092170715332,
+        "Error": 3.172907829284668
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.804463863372803,
+        "Error": -0.8044638633728027
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Nyck de Vries",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.32192611694336,
+        "Error": -0.3219261169433594
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.586023330688477,
+        "Error": 1.4139766693115234
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.817867279052734,
+        "Error": -0.8178672790527344
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 13.935029029846191,
+        "Error": -1.9350290298461914
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Isack Hadjar",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.5875139236450195,
+        "Error": 0.41248607635498047
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.827848434448242,
+        "Error": -0.8278484344482422
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 17.770477294921875,
+        "Error": 0.229522705078125
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.931288719177246,
+        "Error": 1.068711280822754
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 12.513955116271973,
+        "Error": 1.4860448837280273
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.207175254821777,
+        "Error": -0.20717525482177734
+      },
+      {
+        "constructorName": "Cadillac",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 10.662690162658691,
+        "Error": 2.3373098373413086
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.392951011657715,
+        "Error": -0.39295101165771484
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.694345474243164,
+        "Error": -0.6943454742431641
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.2606875896453857,
+        "Error": -0.26068758964538574
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.68622875213623,
+        "Error": 0.31377124786376953
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 11.085151672363281,
+        "Error": -2.0851516723632812
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 3.085801839828491,
+        "Error": 1.9141981601715088
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.613958835601807,
+        "Error": -1.6139588356018066
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 4.385385036468506,
+        "Error": -2.385385036468506
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.136404514312744,
+        "Error": -0.13640451431274414
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 10.107150077819824,
+        "Error": -3.107150077819824
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.120911598205566,
+        "Error": 1.8790884017944336
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.464735507965088,
+        "Error": 0.5352644920349121
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.467790603637695,
+        "Error": -0.4677906036376953
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.182013034820557,
+        "Error": -0.18201303482055664
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.3506433963775635,
+        "Error": -0.3506433963775635
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.786948204040527,
+        "Error": 2.2130517959594727
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.912186861038208,
+        "Error": 0.08781313896179199
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.473149299621582,
+        "Error": -1.473149299621582
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.953984260559082,
+        "Error": -0.953984260559082
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.90712308883667,
+        "Error": -0.9071230888366699
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 3.630211114883423,
+        "Error": -2.630211114883423
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.024837493896484,
+        "Error": -1.0248374938964844
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.7425355911254883,
+        "Error": -0.7425355911254883
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 15.752185821533203,
+        "Error": 1.2478141784667969
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Kimi Antonelli",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 4.585833549499512,
+        "Error": 11.414166450500488
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Oliver Bearman",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 14.617012023925781,
+        "Error": 4.382987976074219
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.8612637519836426,
+        "Error": -0.8612637519836426
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 9.21061897277832,
+        "Error": -1.2106189727783203
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Robert Kubica",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.693928718566895,
+        "Error": -0.6939287185668945
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 14.727127075195312,
+        "Error": -1.7271270751953125
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.541335105895996,
+        "Error": -0.5413351058959961
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.554492950439453,
+        "Error": -0.5544929504394531
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 11.823033332824707,
+        "Error": 3.176966667175293
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.7981966733932495,
+        "Error": -0.7981966733932495
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Nicholas Latifi",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 16.83336639404297,
+        "Error": 1.1666336059570312
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 6.736049175262451,
+        "Error": 0.26395082473754883
+      },
+      {
+        "constructorName": "RB",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 11.609928131103516,
+        "Error": -3.6099281311035156
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.579604148864746,
+        "Error": -0.5796041488647461
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.495699882507324,
+        "Error": -0.4956998825073242
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 16.79458236694336,
+        "Error": -0.7945823669433594
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Franco Colapinto",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.164521217346191,
+        "Error": -0.1645212173461914
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.393031358718872,
+        "Error": 0.6069686412811279
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 15.318111419677734,
+        "Error": -0.3181114196777344
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.413838386535645,
+        "Error": -0.41383838653564453
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 12.297170639038086,
+        "Error": -2.297170639038086
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.641061782836914,
+        "Error": 0.35893821716308594
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 3.769073724746704,
+        "Error": 1.230926275253296
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.141798257827759,
+        "Error": -0.1417982578277588
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.9331789016723633,
+        "Error": 0.06682109832763672
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.7398681640625,
+        "Error": 2.2601318359375
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Guanyu Zhou",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.103939056396484,
+        "Error": -1.1039390563964844
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.307398796081543,
+        "Error": -1.307398796081543
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 12.713581085205078,
+        "Error": -6.713581085205078
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.717671394348145,
+        "Error": -1.7176713943481445
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 8.497417449951172,
+        "Error": -4.497417449951172
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.667016983032227,
+        "Error": 1.3329830169677734
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 3.59989595413208,
+        "Error": -0.5998959541320801
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.4574613571167,
+        "Error": 0.5425386428833008
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Kevin Magnussen",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 14.036599159240723,
+        "Error": -0.036599159240722656
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.979870796203613,
+        "Error": -0.9798707962036133
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 12.840577125549316,
+        "Error": 1.1594228744506836
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 8.737997055053711,
+        "Error": 0.26200294494628906
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 12.50626277923584,
+        "Error": -3.50626277923584
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 5.333897590637207,
+        "Error": 0.666102409362793
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.112833023071289,
+        "Error": 0.8871669769287109
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.518636703491211,
+        "Error": 0.48136329650878906
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Liam Lawson",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.798701286315918,
+        "Error": 2.201298713684082
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.649906158447266,
+        "Error": 1.3500938415527344
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Jolyon Palmer",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 12.383630752563477,
+        "Error": 2.6163692474365234
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.920072555541992,
+        "Error": 0.07992744445800781
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 12.435386657714844,
+        "Error": -3.4353866577148438
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.948342323303223,
+        "Error": -1.9483423233032227
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.980233192443848,
+        "Error": 0.019766807556152344
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 14.168291091918945,
+        "Error": 2.8317089080810547
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Liam Lawson",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 17.558429718017578,
+        "Error": 0.4415702819824219
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Yuki Tsunoda",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.536083221435547,
+        "Error": -0.5360832214355469
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 15.050012588500977,
+        "Error": -0.05001258850097656
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.631498336791992,
+        "Error": -0.6314983367919922
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 15.020035743713379,
+        "Error": 2.979964256286621
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.369878768920898,
+        "Error": 0.6301212310791016
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 14.086554527282715,
+        "Error": -1.0865545272827148
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Liam Lawson",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.652458190917969,
+        "Error": 1.3475418090820312
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 9.0,
+        "PredictedFinalPosition": 10.229178428649902,
+        "Error": -1.2291784286499023
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 1.9795430898666382,
+        "Error": -0.9795430898666382
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.812931060791016,
+        "Error": 0.18706893920898438
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 9.492803573608398,
+        "Error": 0.5071964263916016
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 1.3506653308868408,
+        "Error": 0.6493346691131592
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Guti\u00e9rrez",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.434819221496582,
+        "Error": -0.43481922149658203
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.019230842590332,
+        "Error": -0.01923084259033203
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Oscar Piastri",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 2.826110601425171,
+        "Error": 1.173889398574829
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 12.664224624633789,
+        "Error": -0.6642246246337891
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.8165364265441895,
+        "Error": -0.8165364265441895
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.353562355041504,
+        "Error": -0.3535623550415039
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 15.98780345916748,
+        "Error": 0.012196540832519531
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.0057480335235596,
+        "Error": -0.00574803352355957
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.341849327087402,
+        "Error": 0.6581506729125977
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.66183614730835,
+        "Error": -0.6618361473083496
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.8898541927337646,
+        "Error": -0.8898541927337646
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 12.710833549499512,
+        "Error": -1.7108335494995117
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.9535486698150635,
+        "Error": 0.04645133018493652
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 13.104912757873535,
+        "Error": -0.10491275787353516
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 12.869562149047852,
+        "Error": 5.130437850952148
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.489440441131592,
+        "Error": -0.4894404411315918
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 1.0,
+        "PredictedFinalPosition": 2.076636552810669,
+        "Error": -1.076636552810669
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.679329872131348,
+        "Error": -1.6793298721313477
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.334678649902344,
+        "Error": -0.33467864990234375
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Antonio Giovinazzi",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 10.430678367614746,
+        "Error": 0.5693216323852539
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 7.408895492553711,
+        "Error": 0.5911045074462891
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Logan Sargeant",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 17.579994201660156,
+        "Error": -1.5799942016601562
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 13.39770221710205,
+        "Error": 1.6022977828979492
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 17.28192710876465,
+        "Error": 0.7180728912353516
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.925683975219727,
+        "Error": 0.07431602478027344
+      },
+      {
+        "constructorName": "Audi",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 10.96633243560791,
+        "Error": 1.0336675643920898
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 11.314208030700684,
+        "Error": -1.3142080307006836
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 11.10035514831543,
+        "Error": 3.8996448516845703
+      },
+      {
+        "constructorName": "Racing Bulls",
+        "resultsDriverName": "Liam Lawson",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 13.405841827392578,
+        "Error": 0.5941581726074219
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.627772331237793,
+        "Error": -1.627772331237793
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 10.325399398803711,
+        "Error": 4.674600601196289
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 11.50806999206543,
+        "Error": 5.49193000793457
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Nico H\u00fclkenberg",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 11.892335891723633,
+        "Error": 0.10766410827636719
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 5.455615520477295,
+        "Error": -0.4556155204772949
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.139336109161377,
+        "Error": -0.13933610916137695
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 1.981320858001709,
+        "Error": 1.018679141998291
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Max Verstappen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.448707580566406,
+        "Error": -1.4487075805664062
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 11.0,
+        "PredictedFinalPosition": 11.14295768737793,
+        "Error": -0.1429576873779297
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Nico Rosberg",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.044837236404419,
+        "Error": -0.044837236404418945
+      },
+      {
+        "constructorName": "Toro Rosso",
+        "resultsDriverName": "Brendon Hartley",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 16.11774253845215,
+        "Error": 0.8822574615478516
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Nico Rosberg",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.065783500671387,
+        "Error": -1.0657835006713867
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.72324800491333,
+        "Error": -1.72324800491333
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Romain Grosjean",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 12.615286827087402,
+        "Error": 0.38471317291259766
+      },
+      {
+        "constructorName": "AlphaTauri",
+        "resultsDriverName": "Daniil Kvyat",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 14.272838592529297,
+        "Error": -2.272838592529297
+      },
+      {
+        "constructorName": "Kick Sauber",
+        "resultsDriverName": "Gabriel Bortoleto",
+        "ActualFinalPosition": 19.0,
+        "PredictedFinalPosition": 16.204214096069336,
+        "Error": 2.795785903930664
+      },
+      {
+        "constructorName": "Renault",
+        "resultsDriverName": "Daniel Ricciardo",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 4.659951210021973,
+        "Error": 0.34004878997802734
+      },
+      {
+        "constructorName": "Racing Point",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 7.577167987823486,
+        "Error": 2.4228320121765137
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.4575812816619873,
+        "Error": -0.4575812816619873
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 8.0,
+        "PredictedFinalPosition": 6.183538913726807,
+        "Error": 1.8164610862731934
+      },
+      {
+        "constructorName": "Force India",
+        "resultsDriverName": "Esteban Ocon",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.587162971496582,
+        "Error": -0.587162971496582
+      },
+      {
+        "constructorName": "Red Bull",
+        "resultsDriverName": "Sergio P\u00e9rez",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 8.783150672912598,
+        "Error": -1.7831506729125977
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 15.171916961669922,
+        "Error": -0.17191696166992188
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 4.580260753631592,
+        "Error": -0.5802607536315918
+      },
+      {
+        "constructorName": "Mercedes",
+        "resultsDriverName": "Valtteri Bottas",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 4.157309055328369,
+        "Error": -1.1573090553283691
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Lewis Hamilton",
+        "ActualFinalPosition": 12.0,
+        "PredictedFinalPosition": 8.38946533203125,
+        "Error": 3.61053466796875
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Carlos Sainz Jr.",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.674159526824951,
+        "Error": -0.6741595268249512
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Alexander Albon",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 6.6932573318481445,
+        "Error": -1.6932573318481445
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 2.1121509075164795,
+        "Error": -0.11215090751647949
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "George Russell",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 14.14295482635498,
+        "Error": 1.8570451736450195
+      },
+      {
+        "constructorName": "Haas",
+        "resultsDriverName": "Mick Schumacher",
+        "ActualFinalPosition": 18.0,
+        "PredictedFinalPosition": 14.326953887939453,
+        "Error": 3.673046112060547
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.430397033691406,
+        "Error": 0.5696029663085938
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 16.0,
+        "PredictedFinalPosition": 12.968250274658203,
+        "Error": 3.031749725341797
+      },
+      {
+        "constructorName": "Alfa Romeo",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 15.0,
+        "PredictedFinalPosition": 14.655675888061523,
+        "Error": 0.34432411193847656
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Pascal Wehrlein",
+        "ActualFinalPosition": 14.0,
+        "PredictedFinalPosition": 12.315096855163574,
+        "Error": 1.6849031448364258
+      },
+      {
+        "constructorName": "Williams",
+        "resultsDriverName": "Felipe Massa",
+        "ActualFinalPosition": 6.0,
+        "PredictedFinalPosition": 6.701847553253174,
+        "Error": -0.7018475532531738
+      },
+      {
+        "constructorName": "McLaren",
+        "resultsDriverName": "Lando Norris",
+        "ActualFinalPosition": 5.0,
+        "PredictedFinalPosition": 4.0734381675720215,
+        "Error": 0.9265618324279785
+      },
+      {
+        "constructorName": "Sauber",
+        "resultsDriverName": "Marcus Ericsson",
+        "ActualFinalPosition": 17.0,
+        "PredictedFinalPosition": 13.041526794433594,
+        "Error": 3.9584732055664062
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Lance Stroll",
+        "ActualFinalPosition": 13.0,
+        "PredictedFinalPosition": 11.48990535736084,
+        "Error": 1.5100946426391602
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Charles Leclerc",
+        "ActualFinalPosition": 4.0,
+        "PredictedFinalPosition": 5.947581768035889,
+        "Error": -1.9475817680358887
+      },
+      {
+        "constructorName": "Ferrari",
+        "resultsDriverName": "Kimi R\u00e4ikk\u00f6nen",
+        "ActualFinalPosition": 3.0,
+        "PredictedFinalPosition": 2.471831798553467,
+        "Error": 0.5281682014465332
+      },
+      {
+        "constructorName": "Alpine",
+        "resultsDriverName": "Pierre Gasly",
+        "ActualFinalPosition": 7.0,
+        "PredictedFinalPosition": 7.8748555183410645,
+        "Error": -0.8748555183410645
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Sebastian Vettel",
+        "ActualFinalPosition": 2.0,
+        "PredictedFinalPosition": 3.9362099170684814,
+        "Error": -1.9362099170684814
+      },
+      {
+        "constructorName": "Aston Martin",
+        "resultsDriverName": "Fernando Alonso",
+        "ActualFinalPosition": 10.0,
+        "PredictedFinalPosition": 10.219743728637695,
+        "Error": -0.2197437286376953
+      }
+    ]
+  }
+}

--- a/debug_qualifying_features.py
+++ b/debug_qualifying_features.py
@@ -8,11 +8,10 @@ import sys
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
-from raceAnalysis import load_data, CACHE_VERSION, DATA_DIR
+from raceAnalysis import load_data, get_data_fingerprint, CACHE_VERSION, DATA_DIR
 
 print("Loading data...")
-csv_mtime = os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
-data, _ = load_data(10000, CACHE_VERSION, csv_mtime)
+data, _ = load_data(10000, CACHE_VERSION, get_data_fingerprint()['data_sha256'])
 
 print(f"Data shape: {data.shape}")
 print(f"Columns: {len(data.columns)}\n")

--- a/model_artifacts.py
+++ b/model_artifacts.py
@@ -1,0 +1,52 @@
+"""Content fingerprints shared by model-training jobs and the Streamlit app."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from pathlib import Path
+from typing import Any, MutableMapping
+
+
+FINGERPRINT_ALGORITHM = "sha256"
+
+
+def build_data_fingerprint(data_path: str | Path) -> dict[str, Any]:
+    """Return stable content metadata for a model's source dataset."""
+    path = Path(data_path)
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+
+    return {
+        "data_file": path.name,
+        "data_sha256": digest.hexdigest(),
+        "data_size": path.stat().st_size,
+        "fingerprint_algorithm": FINGERPRINT_ALGORITHM,
+    }
+
+
+def stamp_artifact(
+    artifact: MutableMapping[str, Any],
+    fingerprint: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    """Attach a previously computed dataset fingerprint to an artifact."""
+    for key in ("data_file", "data_sha256", "data_size", "fingerprint_algorithm"):
+        artifact[key] = fingerprint[key]
+    return artifact
+
+
+def artifact_matches_fingerprint(
+    artifact: MutableMapping[str, Any],
+    fingerprint: MutableMapping[str, Any],
+) -> bool | None:
+    """Return True/False for fingerprinted artifacts, or None for legacy ones."""
+    artifact_digest = artifact.get("data_sha256")
+    if not artifact_digest:
+        return None
+    if artifact.get("fingerprint_algorithm", FINGERPRINT_ALGORITHM) != FINGERPRINT_ALGORITHM:
+        return False
+    if artifact.get("data_file") not in (None, fingerprint["data_file"]):
+        return False
+    return hmac.compare_digest(str(artifact_digest), str(fingerprint["data_sha256"]))

--- a/raceAnalysis.py
+++ b/raceAnalysis.py
@@ -11,6 +11,13 @@ import streamlit as st
 import numpy as np
 from pathlib import Path
 import warnings
+from model_artifacts import artifact_matches_fingerprint, build_data_fingerprint
+
+# Pickled custom estimators refer to this module as ``raceAnalysis``. Streamlit
+# executes the entrypoint as ``__main__``; aliasing it prevents pickle from
+# importing and executing the complete app a second time during model loading.
+if __name__ == "__main__":
+    sys.modules.setdefault("raceAnalysis", sys.modules[__name__])
 # suppress pandas FutureWarning about silent downcasting on fillna; prefer
 # explicit infer_objects where possible, otherwise silence the noisy warning
 warnings.filterwarnings(
@@ -42,7 +49,6 @@ from sklearn.preprocessing import OneHotEncoder, StandardScaler
 from sklearn.pipeline import Pipeline
 from sklearn.compose import ColumnTransformer
 from sklearn.metrics import mean_squared_error, r2_score, mean_absolute_error
-from sklearn.inspection import permutation_importance
 from sklearn.impute import SimpleImputer
 from sklearn.experimental import enable_iterative_imputer  # noqa: F401 – must import before IterativeImputer
 from sklearn.impute import IterativeImputer
@@ -222,8 +228,8 @@ class PositionGroupEnsemble(BaseEstimator, RegressorMixin):
 class TrackWeightedEnsemble(BaseEstimator, RegressorMixin):
     """Three sub-models (XGB / LGBM / CAT) blended with track-type-specific weights.
 
-    Call `set_circuit_type(circuit_type)` before `predict()` to apply the
-    appropriate weights from CIRCUIT_ENSEMBLE_WEIGHTS.
+    Use `predict_for_circuit(X, circuit_type)` for shared cached instances so
+    predictions do not mutate cross-session state.
     """
 
     def __init__(self, xgb_model=None, lgbm_model=None, cat_model=None,
@@ -239,8 +245,12 @@ class TrackWeightedEnsemble(BaseEstimator, RegressorMixin):
         return self
 
     def predict(self, X):
+        return self.predict_for_circuit(X, self.circuit_type)
+
+    def predict_for_circuit(self, X, circuit_type: str):
+        """Predict with per-call weights without mutating the shared model."""
         weights = CIRCUIT_ENSEMBLE_WEIGHTS.get(
-            self.circuit_type, CIRCUIT_ENSEMBLE_WEIGHTS['mixed']
+            circuit_type, CIRCUIT_ENSEMBLE_WEIGHTS['mixed']
         )
         pred_xgb  = self.xgb_model.predict(X)
         pred_lgbm = self.lgbm_model.predict(X)
@@ -296,6 +306,20 @@ DATA_DIR = 'data_files/'
 # Cache version - increment this when preprocessor logic changes
 CACHE_VERSION = "v3.3"  # Bumped: Drop NaN/inf rows instead of filling (matches precompute script)
 
+
+@st.cache_data(max_entries=4, show_spinner=False)
+def _cached_data_fingerprint(file_path, file_size, file_mtime_ns):
+    """Hash a local data file, using stat fields only to invalidate this cache."""
+    del file_size, file_mtime_ns
+    return build_data_fingerprint(file_path)
+
+
+def get_data_fingerprint(file_name='f1ForAnalysis.csv'):
+    """Return a stable content fingerprint without using mtime as validity."""
+    file_path = Path(DATA_DIR) / file_name
+    stat = file_path.stat()
+    return _cached_data_fingerprint(str(file_path), stat.st_size, stat.st_mtime_ns)
+
 # Preprocessor used when training the main position model. Set during training so
 # prediction uses the exact same feature ordering and transforms (prevents
 # feature-shape mismatches between training and prediction environments).
@@ -316,7 +340,7 @@ def is_preprocessor_valid(preprocessor, X):
         if hasattr(preprocessor, 'feature_names_in_'):
             missing = set(preprocessor.feature_names_in_) - set(X.columns)
             if missing:
-                print(f"INFO: Preprocessor is stale — missing columns: {missing}. Will retrain.")
+                print(f"INFO: Preprocessor is incompatible — missing columns: {missing}. Will reload artifact.")
                 return False
             return True
         # Fallback: inspect each transformer's column list
@@ -325,7 +349,7 @@ def is_preprocessor_valid(preprocessor, X):
                 if isinstance(cols, list):
                     missing = set(cols) - set(X.columns)
                     if missing:
-                        print(f"INFO: Preprocessor is stale — missing columns: {missing}. Will retrain.")
+                        print(f"INFO: Preprocessor is incompatible — missing columns: {missing}. Will reload artifact.")
                         return False
         return True
     except Exception:
@@ -1042,14 +1066,14 @@ raceNoEarlierThan = current_year - 10
 
 # start = time.time()
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_correlation(nrows, CACHE_VERSION):
     correlation_matrix = pd.read_csv(path.join(DATA_DIR, 'f1PositionCorrelation.csv'), sep='\t', nrows=nrows)
     return correlation_matrix
 
 correlation_matrix = load_correlation(10000, CACHE_VERSION)
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_data_schedule(nrows, CACHE_VERSION):
     raceSchedule = pd.read_json(path.join(DATA_DIR, 'f1db-races.json'))
     grandPrix = pd.read_json(path.join(DATA_DIR, 'f1db-grands-prix.json'))
@@ -1059,14 +1083,14 @@ def load_data_schedule(nrows, CACHE_VERSION):
 
 raceSchedule = load_data_schedule(10000, CACHE_VERSION)
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_drivers(nrows, CACHE_VERSION):
     drivers = pd.read_json(path.join(DATA_DIR, 'f1db-drivers.json'))
     return drivers
 
 drivers = load_drivers(10000, CACHE_VERSION)
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_qualifying(nrows):
     # Include cache version to invalidate when preprocessor changes
     _ = CACHE_VERSION
@@ -1075,7 +1099,7 @@ def load_qualifying(nrows):
 
 qualifying = load_qualifying(10000)
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_practices(nrows, CACHE_VERSION):
     practices = pd.read_csv(path.join(DATA_DIR, 'all_practice_laps.csv'), sep='\t', dtype={'PitOutTime': str}) 
     practices = practices[practices['Driver'] != 'ERROR']  # Remove rows where Driver is 'ERROR'
@@ -1083,7 +1107,7 @@ def load_practices(nrows, CACHE_VERSION):
 
 practices = load_practices(10000, CACHE_VERSION)
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_data_race_messages(nrows, CACHE_VERSION):
     race_messages = pd.read_csv(path.join(DATA_DIR, 'race_control_messages_grouped_with_dnf.csv'),sep='\t')
     return race_messages
@@ -1145,7 +1169,7 @@ schedule_columns_to_display = {
     'sprintQualifyingTime': None,   
 }
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_weather_data(nrows, CACHE_VERSION):
     weather = pd.read_csv(path.join(DATA_DIR, 'f1WeatherData_Grouped.csv'), sep='\t', nrows=nrows, usecols=['grandPrixId', 'short_date', 'average_temp', 'total_precipitation', 'average_humidity', 'average_wind_speed', 'id_races'])
     grandPrix = pd.read_json(path.join(DATA_DIR, 'f1db-grands-prix.json'))
@@ -1155,7 +1179,7 @@ def load_weather_data(nrows, CACHE_VERSION):
 weatherData = load_weather_data(10000, CACHE_VERSION)
 
 # Precomputed analysis loaders
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_precomputed_monte_carlo(CACHE_VERSION):
     """Load precomputed Monte Carlo feature selection results."""
     try:
@@ -1167,7 +1191,7 @@ def load_precomputed_monte_carlo(CACHE_VERSION):
         st.warning(f"Could not load precomputed Monte Carlo results: {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_precomputed_shap(CACHE_VERSION):
     """Load precomputed SHAP analysis results."""
     try:
@@ -1179,7 +1203,7 @@ def load_precomputed_shap(CACHE_VERSION):
         st.warning(f"Could not load precomputed SHAP results: {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_precomputed_rfe(CACHE_VERSION):
     """Load precomputed RFE results."""
     try:
@@ -1191,7 +1215,7 @@ def load_precomputed_rfe(CACHE_VERSION):
         st.warning(f"Could not load precomputed RFE results: {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_precomputed_boruta(CACHE_VERSION):
     """Load precomputed Boruta results."""
     try:
@@ -1203,7 +1227,7 @@ def load_precomputed_boruta(CACHE_VERSION):
         st.warning(f"Could not load precomputed Boruta results: {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_precomputed_permutation(CACHE_VERSION):
     """Load precomputed permutation importance results."""
     try:
@@ -1215,7 +1239,19 @@ def load_precomputed_permutation(CACHE_VERSION):
         st.warning(f"Could not load precomputed permutation results: {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=1)
+def load_precomputed_historical_validation(CACHE_VERSION):
+    """Load workflow-generated cross-validation and holdout results."""
+    try:
+        precomputed_path = path.join(DATA_DIR, 'precomputed', 'historical_validation.json')
+        if path.exists(precomputed_path):
+            with open(precomputed_path, 'r') as f:
+                return json.load(f)
+    except Exception as e:
+        st.warning(f"Could not load precomputed historical validation: {e}")
+    return None
+
+@st.cache_data(max_entries=2)
 def load_precomputed_hyperparams(method='bayesian', CACHE_VERSION=None):
     """Load precomputed hyperparameter optimization results.
     
@@ -1233,7 +1269,7 @@ def load_precomputed_hyperparams(method='bayesian', CACHE_VERSION=None):
         st.warning(f"Could not load precomputed hyperparameters ({method}): {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_precomputed_position_mae(CACHE_VERSION):
     """Load precomputed position group MAE analysis."""
     try:
@@ -1245,7 +1281,7 @@ def load_precomputed_position_mae(CACHE_VERSION):
         st.warning(f"Could not load precomputed position MAE: {e}")
     return None
 
-@st.cache_data
+@st.cache_data(max_entries=8)
 def load_precomputed_predictions(race_name=None, year=None, CACHE_VERSION=None):
     """Load precomputed next race predictions.
     
@@ -1280,7 +1316,7 @@ def load_precomputed_predictions(race_name=None, year=None, CACHE_VERSION=None):
     return None
 
 
-@st.cache_data
+@st.cache_data(max_entries=2)
 def load_tire_strategy_data(CACHE_VERSION, csv_mtime=None):
     """Load tire strategy data from FastF1 backfill (2018–present).
 
@@ -1544,16 +1580,13 @@ season_summary_columns_to_display = {
     'total_podiums': st.column_config.NumberColumn("Total Podiums", format="%d")
 }
 
-@st.cache_data
-def load_data(nrows, CACHE_VERSION, csv_mtime=None):
-    # Note: csv_mtime is included as a cache key so updating the CSV file
-    # will automatically invalidate the cache. Callers should pass
-    # os.path.getmtime(DATA_DIR/"f1ForAnalysis.csv"). If None, compute it.
-    if csv_mtime is None:
-        try:
-            csv_mtime = os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
-        except Exception:
-            csv_mtime = 0
+@st.cache_data(max_entries=1)
+def load_data(nrows, CACHE_VERSION, data_sha256=None):
+    # data_sha256 is a stable cache key. Unlike a checkout mtime, it changes
+    # only when file content changes, so hot updates do not accumulate large
+    # cached DataFrames for identical data.
+    if data_sha256 is None:
+        data_sha256 = get_data_fingerprint()['data_sha256']
     # Read the header only to get all column names
     all_columns = pd.read_csv(path.join(DATA_DIR, 'f1ForAnalysis.csv'), sep='\t', nrows=0).columns.tolist()
     selected_columns = ['grandPrixYear', 'grandPrixName', 'resultsDriverName', 'resultsPodium', 'resultsTop5', 'resultsTop10', 'constructorName',  'resultsStartingGridPositionNumber', 'resultsFinalPositionNumber', 
@@ -1657,7 +1690,7 @@ def load_data(nrows, CACHE_VERSION, csv_mtime=None):
 data, pitStops = load_data(
     10000,
     CACHE_VERSION,
-    os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+    get_data_fingerprint()['data_sha256']
 )
 
 # Debug: Check what columns were actually loaded
@@ -2217,7 +2250,7 @@ def get_preprocessor_safety_car():
     )
     return preprocessor
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def load_safetycars(nrows, CACHE_VERSION):
     safety_cars = pd.read_csv(path.join(DATA_DIR, 'f1SafetyCarFeatures.csv'), sep='\t', nrows=nrows)
     safety_cars = safety_cars.drop_duplicates()
@@ -2576,7 +2609,6 @@ def train_and_evaluate_model(data, early_stopping_rounds=20, model_type="XGBoost
         return model, mse, r2, mae, mean_err, evals_result, preprocessor
 
 
-@st.cache_data
 def train_and_evaluate_dnf_model(data, CACHE_VERSION):
     from sklearn.linear_model import LogisticRegression
     X, y = get_features_and_target_dnf(data)
@@ -2589,7 +2621,6 @@ def train_and_evaluate_dnf_model(data, CACHE_VERSION):
     return model
 
 
-@st.cache_data
 def train_and_evaluate_safetycar_model(data, CACHE_VERSION):
     from sklearn.linear_model import LogisticRegression
     X, y = get_features_and_target_safety_car(data)
@@ -2605,101 +2636,143 @@ def train_and_evaluate_safetycar_model(data, CACHE_VERSION):
 
     return model
 
-def load_pretrained_model(model_name='position_model', CACHE_VERSION='v2.3', model_type=None):
-    """Load a pre-trained model from disk if available.
+_MODEL_TYPE_TO_DIR = {
+    'XGBoost': 'xgboost',
+    'LightGBM': 'lightgbm',
+    'CatBoost': 'catboost',
+    'Ensemble (XGBoost + LightGBM + CatBoost)': 'ensemble',
+    'Position Group': 'position_group',
+    'Track-Weighted Ensemble': 'track_weighted',
+}
 
-    When *model_type* is provided the matching sub-directory is searched first
-    (and exclusively for position models) so the right model is always returned.
-    """
+_MODEL_TYPE_ARTIFACT_LABELS = {
+    'XGBoost': {'XGBoost'},
+    'LightGBM': {'LightGBM'},
+    'CatBoost': {'CatBoost'},
+    'Ensemble (XGBoost + LightGBM + CatBoost)': {
+        'Ensemble', 'Ensemble (XGBoost + LightGBM + CatBoost)'
+    },
+    'Position Group': {'Position Group'},
+    'Track-Weighted Ensemble': {'Track-Weighted Ensemble'},
+}
+
+
+class PretrainedModelUnavailableError(RuntimeError):
+    """Raised when a compatible workflow-generated artifact is unavailable."""
+
+
+def _model_search_paths(model_name, model_type=None):
+    if model_type and model_type in _MODEL_TYPE_TO_DIR:
+        subdir = _MODEL_TYPE_TO_DIR[model_type]
+        return [
+            Path(DATA_DIR) / 'models' / subdir / f'{model_name}.pkl',
+            Path(DATA_DIR) / 'models' / f'{model_name}.pkl',
+        ]
+    return [
+        Path(DATA_DIR) / 'models' / 'xgboost' / f'{model_name}.pkl',
+        Path(DATA_DIR) / 'models' / 'lightgbm' / f'{model_name}.pkl',
+        Path(DATA_DIR) / 'models' / 'catboost' / f'{model_name}.pkl',
+        Path(DATA_DIR) / 'models' / 'ensemble' / f'{model_name}.pkl',
+        Path(DATA_DIR) / 'models' / f'{model_name}.pkl',
+    ]
+
+
+@st.cache_resource(max_entries=8, show_spinner=False)
+def _load_pretrained_model_resource(
+    model_name,
+    cache_version,
+    model_type,
+    data_fingerprint,
+    artifact_signature,
+):
+    """Load one shared model object; signatures invalidate changed files."""
+    del artifact_signature
     import pickle
-    from pathlib import Path
 
-    # Map UI drop-down label → directory name
-    _type_to_dir = {
-        'XGBoost': 'xgboost',
-        'LightGBM': 'lightgbm',
-        'CatBoost': 'catboost',
-        'Ensemble (XGBoost + LightGBM + CatBoost)': 'ensemble',
-        'Position Group': 'position_group',       # ROADMAP-3A
-        'Track-Weighted Ensemble': 'track_weighted',  # ROADMAP-3E
-    }
+    stale_fallback = None
+    for model_file in _model_search_paths(model_name, model_type):
+        if not model_file.exists():
+            continue
+        try:
+            with model_file.open('rb') as source:
+                artifact = pickle.load(source)
+        except Exception as exc:
+            print(f"WARNING: Could not load pre-trained {model_name} from {model_file}: {exc}")
+            continue
 
-    csv_path = Path(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
-    csv_mtime = csv_path.stat().st_mtime if csv_path.exists() else 0
-
-    # Build search list.  If model_type is given, look ONLY in its directory
-    # (plus the legacy root as a fallback).  If not given, preserve the old
-    # behaviour of trying all four directories in order.
-    if model_type and model_type in _type_to_dir:
-        subdir = _type_to_dir[model_type]
-        search_paths = [
-            Path(f'data_files/models/{subdir}') / f'{model_name}.pkl',
-            Path('data_files/models') / f'{model_name}.pkl',  # legacy fallback
-        ]
-    else:
-        search_paths = [
-            Path('data_files/models/xgboost') / f'{model_name}.pkl',
-            Path('data_files/models/lightgbm') / f'{model_name}.pkl',
-            Path('data_files/models/catboost') / f'{model_name}.pkl',
-            Path('data_files/models/ensemble') / f'{model_name}.pkl',
-            Path('data_files/models') / f'{model_name}.pkl',  # Legacy location
-        ]
-    
-    for model_file in search_paths:
-        if model_file.exists():
-            # Reject pkl that is older than the CSV (stale model)
-            if model_file.stat().st_mtime < csv_mtime:
-                print(f"INFO: Skipping stale pre-trained model at {model_file} (older than CSV). Will retrain.")
+        if not isinstance(artifact, dict) or artifact.get('cache_version') != cache_version:
+            print(f"INFO: Ignoring incompatible pre-trained model at {model_file}.")
+            continue
+        if model_name == 'position_model' and model_type:
+            allowed_labels = _MODEL_TYPE_ARTIFACT_LABELS.get(model_type, {model_type})
+            if artifact.get('model_type') not in allowed_labels:
+                print(f"INFO: Ignoring wrong model type at {model_file}.")
                 continue
-            try:
-                with open(model_file, 'rb') as f:
-                    artifact = pickle.load(f)
-                
-                # Check cache version compatibility
-                if artifact.get('cache_version') == CACHE_VERSION:
-                    return artifact
-                else:
-                    st.info(f"Pre-trained {model_name} found at {model_file} but cache version mismatch. Will retrain.")
-            except Exception as e:
-                st.warning(f"Error loading pre-trained {model_name} from {model_file}: {e}. Will retrain.")
-    
-    return None
 
-@st.cache_data(max_entries=2)
-def _train_model_cached(early_stopping_rounds, CACHE_VERSION, csv_mtime=None, model_type='XGBoost'):
-    """Live-train the position prediction model (cached).
+        artifact = dict(artifact)
+        artifact['_artifact_path'] = str(model_file)
+        fingerprint_match = artifact_matches_fingerprint(artifact, data_fingerprint)
+        if fingerprint_match is True:
+            artifact['_artifact_status'] = 'current'
+            return artifact
+        if fingerprint_match is None:
+            # Backward compatibility until the next model-training workflow
+            # stamps the already committed artifacts with content hashes.
+            artifact['_artifact_status'] = 'legacy'
+            return artifact
 
-    csv_mtime is included so the cache key changes when f1ForAnalysis.csv updates.
-    model_type is part of the cache key so switching models retrain correctly.
-    max_entries=2 caps simultaneous cached models to avoid OOM on Streamlit Cloud.
+        artifact['_artifact_status'] = 'stale'
+        stale_fallback = stale_fallback or artifact
 
-    Returns (model, mse, r2, mae, mean_err, evals_result, preprocessor)."""
-    model, mse, r2, mae, mean_err, evals_result, preprocessor = train_and_evaluate_model(
-        data, early_stopping_rounds=early_stopping_rounds, model_type=model_type)
-    return model, mse, r2, mae, mean_err, evals_result, preprocessor
+    return stale_fallback
 
 
-def get_trained_model(early_stopping_rounds, CACHE_VERSION, csv_mtime=None, force_retrain=False, model_type='XGBoost'):
-    """Load or train the position prediction model.
+def load_pretrained_model(model_name='position_model', CACHE_VERSION='v2.3', model_type=None):
+    """Load a workflow-generated artifact shared across all user sessions."""
+    data_file = 'f1SafetyCarFeatures.csv' if model_name == 'safetycar_model' else 'f1ForAnalysis.csv'
+    fingerprint = get_data_fingerprint(data_file)
+    search_paths = _model_search_paths(model_name, model_type)
+    artifact_signature = tuple(
+        (str(model_file), model_file.stat().st_size, model_file.stat().st_mtime_ns)
+        for model_file in search_paths
+        if model_file.exists()
+    )
+    return _load_pretrained_model_resource(
+        model_name,
+        CACHE_VERSION,
+        model_type,
+        fingerprint,
+        artifact_signature,
+    )
 
-    The pkl load is intentionally performed OUTSIDE @st.cache_data so that
-    pickle.load (which may re-import raceAnalysis to resolve class references)
-    never runs inside a cached context — which would raise CachedWidgetWarning
-    due to top-level st.* calls in this module.
 
-    Returns (model, mse, r2, mae, mean_err, evals_result, preprocessor)."""
-    # Try to load pre-trained model first (outside cache to avoid CachedWidgetWarning)
-    if not force_retrain:
-        pretrained = load_pretrained_model('position_model', CACHE_VERSION, model_type=model_type)
-        if pretrained is not None:
-            return (pretrained['model'], pretrained['mse'], pretrained['r2'],
-                    pretrained['mae'], pretrained['mean_err'], pretrained['evals_result'],
-                    pretrained.get('preprocessor'))
+def _warn_if_stale_artifact(artifact, label):
+    if artifact.get('_artifact_status') == 'stale':
+        st.warning(
+            f"{label} is using the most recent precomputed model while GitHub Actions "
+            "rebuilds it for the latest dataset. Runtime training is disabled to keep "
+            "the app responsive."
+        )
 
-    # Fall back to live training (cached); clear cache if forced
+
+def get_trained_model(early_stopping_rounds, CACHE_VERSION, data_sha256=None, force_retrain=False, model_type='XGBoost'):
+    """Return a shared pre-trained position model; never train in a page request."""
+    del early_stopping_rounds, data_sha256
     if force_retrain:
-        _train_model_cached.clear()
-    return _train_model_cached(early_stopping_rounds, CACHE_VERSION, csv_mtime, model_type)
+        raise PretrainedModelUnavailableError(
+            "Runtime retraining is disabled. Run the Train All Models GitHub workflow instead."
+        )
+
+    pretrained = load_pretrained_model('position_model', CACHE_VERSION, model_type=model_type)
+    if pretrained is None:
+        raise PretrainedModelUnavailableError(
+            f"No compatible pre-trained {model_type} position model is available. "
+            "Run the Train All Models GitHub workflow."
+        )
+    _warn_if_stale_artifact(pretrained, model_type)
+    return (pretrained['model'], pretrained['mse'], pretrained['r2'],
+            pretrained['mae'], pretrained['mean_err'], pretrained['evals_result'],
+            pretrained.get('preprocessor'))
 
 # Lazy-load models (only when accessed, not at module load)
 def get_main_model():
@@ -2707,12 +2780,12 @@ def get_main_model():
         model, mse, r2, mae, mean_err, evals_result, preprocessor = get_trained_model(
             20,
             CACHE_VERSION,
-            os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+            get_data_fingerprint()['data_sha256']
         )
         st.session_state['main_model'] = model
         st.session_state['global_mae'] = mae
-        # Use a dedicated key so Tab5 re-trains don't overwrite the preprocessor
-        # that is paired with this specific model object.
+        # Use a dedicated key so selecting another precomputed model in Tab5
+        # does not desynchronize this model/preprocessor pair.
         st.session_state['main_model_preprocessor'] = preprocessor
         st.session_state['training_preprocessor'] = preprocessor  # backward compat
         # Also set global for backward compatibility
@@ -2722,7 +2795,7 @@ def get_main_model():
 
 data['DNF'] = data['DNF'].astype(int)
 
-@st.cache_data
+@st.cache_data(max_entries=1)
 def get_dnf_diagnostic_probs(CACHE_VERSION):
     """Lazy-load DNF diagnostic logistic regression probabilities."""
     from sklearn.linear_model import LogisticRegression
@@ -2739,30 +2812,30 @@ def get_dnf_diagnostic_probs(CACHE_VERSION):
         clf.fit(X_dnf_prep, y_dnf)
         return clf.predict_proba(X_dnf_prep)[:, 1]
 
-@st.cache_data
 def get_dnf_model(CACHE_VERSION, force_retrain=False):
-    """Load or train the DNF prediction model."""
-    if not force_retrain:
-        pretrained = load_pretrained_model('dnf_model', CACHE_VERSION)
-        if pretrained is not None:
-            return pretrained['model']
-    return train_and_evaluate_dnf_model(data, CACHE_VERSION)
-
-@st.cache_data
-def _train_safetycar_cached(CACHE_VERSION):
-    return train_and_evaluate_safetycar_model(safety_cars, CACHE_VERSION)
+    """Load the shared workflow-generated DNF model."""
+    if force_retrain:
+        raise PretrainedModelUnavailableError(
+            "Runtime retraining is disabled. Run the Train All Models GitHub workflow instead."
+        )
+    pretrained = load_pretrained_model('dnf_model', CACHE_VERSION)
+    if pretrained is None:
+        raise PretrainedModelUnavailableError("No compatible pre-trained DNF model is available.")
+    _warn_if_stale_artifact(pretrained, 'DNF predictions')
+    return pretrained['model']
 
 
 def get_safetycar_model(CACHE_VERSION, force_retrain=False):
-    """Load or train the safety car prediction model.
-
-    pkl load is outside @st.cache_data for the same reason as get_trained_model
-    (avoids CachedWidgetWarning when pickle.load re-imports raceAnalysis)."""
-    if not force_retrain:
-        pretrained = load_pretrained_model('safetycar_model', CACHE_VERSION)
-        if pretrained is not None:
-            return pretrained['model']
-    return _train_safetycar_cached(CACHE_VERSION)
+    """Load the shared workflow-generated safety-car model."""
+    if force_retrain:
+        raise PretrainedModelUnavailableError(
+            "Runtime retraining is disabled. Run the Train All Models GitHub workflow instead."
+        )
+    pretrained = load_pretrained_model('safetycar_model', CACHE_VERSION)
+    if pretrained is None:
+        raise PretrainedModelUnavailableError("No compatible pre-trained safety-car model is available.")
+    _warn_if_stale_artifact(pretrained, 'Safety-car predictions')
+    return pretrained['model']
 
 # Module-level execution guarded for headless imports
 import os
@@ -2911,11 +2984,11 @@ if _cached_pp is not None:
 
 if 'training_preprocessor' not in st.session_state:
     try:
-        # Use default early stopping for initial load
+        # Load the default workflow-generated XGBoost artifact.
         model, mse, r2, mae, mean_err, evals_result, preprocessor = get_trained_model(
             20,
             CACHE_VERSION,
-            os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+            get_data_fingerprint()['data_sha256']
         )
         st.session_state['main_model'] = model
         st.session_state['global_mae'] = mae
@@ -4161,16 +4234,20 @@ with tab4:
             if model is None:
                 get_main_model()  # trigger lazy load
                 model = st.session_state['main_model']
-            # ROADMAP-3E: for TrackWeightedEnsemble, set the circuit type from
-            # the next race so predictions use the appropriate blend weights.
+            # ROADMAP-3E: choose weights per call. The cached model is shared
+            # across sessions and must remain immutable/thread-safe.
             if isinstance(model, TrackWeightedEnsemble) and not nextRace.empty:
                 _cref = None
                 for _col in ('circuitRef', 'circuitId', 'circuit_ref', 'circuit'):
                     if _col in nextRace.columns:
                         _cref = nextRace[_col].iat[0]
                         break
-                model.set_circuit_type(get_circuit_type(_cref))
-            predicted_position = model.predict(_prep_as_df(X_predict_prep, preprocessor))
+                predicted_position = model.predict_for_circuit(
+                    _prep_as_df(X_predict_prep, preprocessor),
+                    get_circuit_type(_cref),
+                )
+            else:
+                predicted_position = model.predict(_prep_as_df(X_predict_prep, preprocessor))
 
             # Get DNF feature names
             dnf_features, _ = get_features_and_target_dnf(data)
@@ -4203,53 +4280,6 @@ with tab4:
                 predicted_dnf_proba = get_dnf_model(CACHE_VERSION).predict_proba(X_predict_dnf)[:, 1]  # Probability of DNF=True
 
     
-            # Holdout year evaluation for Safety Car Model
-            # Use current year if it has data, otherwise use most recent year with data
-            max_year_with_data = safety_cars['grandPrixYear'].max()
-            holdout_test_year = current_year if current_year <= max_year_with_data else max_year_with_data
-            
-            train = safety_cars[safety_cars['grandPrixYear'] < holdout_test_year]
-            test = safety_cars[safety_cars['grandPrixYear'] == holdout_test_year]
-            X_train, y_train = get_features_and_target_safety_car(train)
-            X_test, y_test = get_features_and_target_safety_car(test)
-
-            holdout_model = train_and_evaluate_safetycar_model(train, CACHE_VERSION)
-            # Now use holdout_model for predictions:
-            # y_pred = holdout_model.predict_proba(X_test)[:, 1]
-            if X_test.shape[0] == 0:
-                st.warning(f"Safety Car holdout test set for year {holdout_test_year} is empty; skipping predictions.")
-                y_pred = np.array([])
-            else:
-                if X_test.isnull().any().any():
-                    X_test = X_test.fillna(X_test.mean(numeric_only=True))
-                y_pred = holdout_model.predict_proba(X_test)[:, 1]
-   
-            # Find the most recent year with both classes present in test set
-            holdout_year = None
-            for year in sorted(safety_cars['grandPrixYear'].unique(), reverse=True):
-                test = safety_cars[safety_cars['grandPrixYear'] == year]
-                if len(test['SafetyCarStatus'].unique()) > 1:
-                    holdout_year = year
-                    break
-
-            if holdout_year is not None:
-                train = safety_cars[safety_cars['grandPrixYear'] < holdout_year]
-                test = safety_cars[safety_cars['grandPrixYear'] == holdout_year]
-                X_train, y_train = get_features_and_target_safety_car(train)
-                X_test, y_test = get_features_and_target_safety_car(test)
-
-                # Do NOT re-fit safetycar_model! Instead, create a new model for holdout/test:
-                holdout_model = train_and_evaluate_safetycar_model(train, CACHE_VERSION)
-                if X_test.shape[0] == 0:
-                    st.warning(f"Safety Car holdout evaluation for year {holdout_year} skipped: test set is empty.")
-                    y_pred = np.array([])
-                else:
-                    y_pred = holdout_model.predict_proba(X_test)[:, 1]
-                    from sklearn.metrics import roc_auc_score
-                    # st.write(f"Safety Car ROC AUC (holdout year {holdout_year}):", roc_auc_score(y_test, y_pred))
-            else:
-                st.write("No valid holdout year with both classes present.")
-
             # Get race-level features for the next race (should be one row)
             race_level = detailsOfNextRace.drop_duplicates(subset=['grandPrixYear', 'grandPrixName'])
 
@@ -4712,10 +4742,6 @@ with tab5:
         help="Choose the machine learning model to use for predictions"
     )
 
-    # explicit retrain button to clear cache and force fresh training
-    #if st.button("Retrain Model (clear cache)"):
-    #    st.session_state['force_retrain'] = True
-
     # Model information expander
     with st.expander("ℹ️ Model Information & Recommendations", expanded=False):
         st.markdown("""
@@ -4771,24 +4797,19 @@ with tab5:
         - **ROADMAP-3 preprocessor** (IterativeImputer + TargetEncoder + RobustScaler) is applied to all model types, providing a shared preprocessing improvement baseline
         """)
     
-    # Early stopping rounds - always visible at top
-    early_stopping_rounds = st.number_input(
-        "Early stopping rounds", min_value=1, max_value=100, value=20, step=1, 
-        help="Number of rounds with no improvement to stop training"
+    st.caption(
+        "Models are pre-trained by GitHub Actions; training controls are kept out "
+        "of the live app to protect responsiveness."
     )
 
-    # Store for use in Tab 4
-    st.session_state['early_stopping_rounds'] = early_stopping_rounds
-
-    # Train model once at the top level for reuse (lazy loading with cache)
-    # determine if user has requested a forced retrain
-    force_flag = st.session_state.pop('force_retrain', False)
+    # Load one shared workflow-generated model for reuse. Discard any legacy
+    # retrain flag left in an existing session after a hot deployment.
+    st.session_state.pop('force_retrain', None)
     try:
         model, mse, r2, mae, mean_err, evals_result, preprocessor = get_trained_model(
-            early_stopping_rounds,
+            20,
             CACHE_VERSION,
-            os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv')),
-            force_retrain=force_flag,
+            get_data_fingerprint()['data_sha256'],
             model_type=model_type,
         )
         
@@ -5218,30 +5239,41 @@ with tab5:
             
             # Permutation Importance
             st.write("### Permutation Importance (Feature Impact on Model Error)")
-            from sklearn.inspection import permutation_importance
-
-            X_feat, y_feat = get_features_and_target(data)
-            mask = y_feat.notnull() & np.isfinite(y_feat)
-            X_feat, y_feat = X_feat[mask], y_feat[mask]
-            preprocessor_feat = get_preprocessor_position(X_feat)
-            X_prep_feat = preprocessor_feat.fit_transform(X_feat)
-            model_feat = XGBRegressor(n_estimators=100, max_depth=4, n_jobs=-1, tree_method='hist', random_state=42)
-            model_feat.fit(X_prep_feat, y_feat)
-
-            result = permutation_importance(model_feat, X_prep_feat, y_feat, n_repeats=10, random_state=42)
-            importances = result.importances_mean
-            feature_names_perm = preprocessor_feat.get_feature_names_out()
-            feature_names_perm = [name.replace('num__', '').replace('cat__', '') for name in feature_names_perm]
-
-            perm_df = pd.DataFrame({
-                'Feature': feature_names_perm,
-                'Permutation Importance': importances
-            }).sort_values(by='Permutation Importance', ascending=True)
-
-            st.write("Features with lowest permutation importance (least helpful):")
-            st.dataframe(perm_df.head(100), hide_index=True, width=800)
-            st.write("Features with highest permutation importance (most helpful):")
-            st.dataframe(perm_df.tail(100).sort_values(by='Permutation Importance', ascending=False), hide_index=True, width=800)
+            precomputed_permutation_analysis = load_precomputed_permutation(CACHE_VERSION)
+            if precomputed_permutation_analysis:
+                permutation_metadata = precomputed_permutation_analysis.get('metadata', {})
+                generated_at = permutation_metadata.get('generated_at') or permutation_metadata.get('timestamp', 'Unknown')
+                st.caption(
+                    f"Precomputed by GitHub Actions: {generated_at} · "
+                    f"{permutation_metadata.get('n_repeats', 'N/A')} repeats"
+                )
+                permutation_rows = (
+                    precomputed_permutation_analysis.get('feature_importance')
+                    or precomputed_permutation_analysis.get('importances')
+                    or []
+                )
+                if permutation_rows:
+                    perm_df = pd.DataFrame(permutation_rows).rename(columns={
+                        'feature': 'Feature',
+                        'importance': 'Permutation Importance',
+                        'std': 'Standard Deviation',
+                    })
+                    perm_df = perm_df.sort_values(by='Permutation Importance', ascending=True)
+                    st.write("Features with lowest permutation importance (least helpful):")
+                    st.dataframe(perm_df.head(100), hide_index=True, width=800)
+                    st.write("Features with highest permutation importance (most helpful):")
+                    st.dataframe(
+                        perm_df.tail(100).sort_values(by='Permutation Importance', ascending=False),
+                        hide_index=True,
+                        width=800,
+                    )
+                else:
+                    st.info("The precomputed permutation artifact contains no feature rows.")
+            else:
+                st.info(
+                    "Permutation importance is generated by the Feature Selection Suite "
+                    "GitHub workflow and is not computed in the live app."
+                )
 
             # High-Cardinality Features
             st.write("### High-Cardinality Features (Potential Overfitting Risk)")
@@ -5377,9 +5409,13 @@ with tab5:
                     if precomputed_permutation:
                         st.write("### Permutation Importance (Precomputed)")
                         metadata = precomputed_permutation.get('metadata', {})
-                        st.write(f"**Computed:** {metadata.get('timestamp', 'Unknown')}")
+                        st.write(f"**Computed:** {metadata.get('generated_at') or metadata.get('timestamp', 'Unknown')}")
                         
-                        importances = precomputed_permutation.get('importances', [])
+                        importances = (
+                            precomputed_permutation.get('feature_importance')
+                            or precomputed_permutation.get('importances')
+                            or []
+                        )
                         if importances:
                             perm_df = pd.DataFrame(importances)
                             st.dataframe(perm_df.head(30), hide_index=True)
@@ -6058,7 +6094,7 @@ with tab5:
                     
                     if group_data:
                         df_groups = pd.DataFrame(group_data)
-                        st.dataframe(df_groups, hide_index=True, use_container_width=True)
+                        st.dataframe(df_groups, hide_index=True, width='stretch')
                         st.caption("Lower MAE indicates better prediction accuracy for that position group. These values match the Model Performance tab.")
                     
                     # Show example predictions for winners to verify the MAE calculation
@@ -6089,7 +6125,7 @@ with tab5:
                             # Show some examples
                             st.write("**Sample predictions (first 10):**")
                             sample_display = winners_data[['Actual', 'Predicted', 'Error', 'AbsError']].head(10).round(3)
-                            st.dataframe(sample_display, hide_index=True, use_container_width=True)
+                            st.dataframe(sample_display, hide_index=True, width='stretch')
                     
                     st.divider()
                 else:
@@ -6332,132 +6368,98 @@ with tab5:
         
         with tab_hist:
             st.subheader("Historical Validation")
-            
-            # Model Evaluation Metrics
-            st.write("### Model Evaluation Metrics (Cross-Validation)")
-            X_eval, y_eval = get_features_and_target(data)
-            mask_eval = y_eval.notnull() & np.isfinite(y_eval)
-            X_eval, y_eval = X_eval[mask_eval], y_eval[mask_eval]
-            
-            # Wrap preprocessor + model in a Pipeline so the preprocessor is
-            # refitted on each training fold — prevents the scaler from seeing
-            # validation-fold statistics (pre-existing preprocessing leakage fix).
-            model_cv = XGBRegressor(n_estimators=100, max_depth=4, n_jobs=-1, tree_method='hist', random_state=42)
-            cv_pipeline = Pipeline([
-                ('pre', get_preprocessor_position(X_eval)),
-                ('model', model_cv),
-            ])
-            scores = cross_val_score(cv_pipeline, X_eval, y_eval, cv=5, scoring='neg_mean_squared_error')
-            avg_mse = -scores.mean()
-            std_mse = scores.std()
-            st.write(f"Final Position Model - Cross-validated MSE: {avg_mse:.3f} (± {std_mse:.3f})")
-
-            X_dnf_eval, y_dnf_eval = get_features_and_target_dnf(data)
-            mask_dnf = y_dnf_eval.notnull() & np.isfinite(y_dnf_eval)
-            X_dnf_eval, y_dnf_eval = X_dnf_eval[mask_dnf], y_dnf_eval[mask_dnf]
-            if X_dnf_eval.shape[0] == 0:
-                st.warning("No data for DNF evaluation; skipping DNF test/CV metrics.")
+            historical_validation = load_precomputed_historical_validation(CACHE_VERSION)
+            if not historical_validation:
+                st.info(
+                    "Historical validation is generated by the Feature Selection Suite "
+                    "GitHub workflow and is not computed in the live app."
+                )
             else:
-                X_train_dnf, X_test_dnf, y_train_dnf, y_test_dnf = train_test_split(X_dnf_eval, y_dnf_eval, test_size=0.2, random_state=42)
-                if X_test_dnf.shape[0] == 0:
-                    st.warning("DNF test split is empty; skipping MAE calculation.")
-                else:
-                    y_pred_dnf_proba = get_dnf_model(CACHE_VERSION).predict_proba(X_test_dnf)[:, 1]
-                    mae_dnf = mean_absolute_error(y_test_dnf, y_pred_dnf_proba)
-                    st.write(f"Mean Absolute Error (MAE) for DNF Probability (test set): {mae_dnf:.3f}")
-                scores_dnf = cross_val_score(get_dnf_model(CACHE_VERSION), X_dnf_eval, y_dnf_eval, cv=5, scoring='roc_auc')
-                st.write(f"DNF Model - Cross-validated ROC AUC: {scores_dnf.mean():.3f} (± {scores_dnf.std():.3f})")
+                validation_metadata = historical_validation.get('metadata', {})
+                generated_at = validation_metadata.get('generated_at', 'Unknown')
+                validation_model_type = validation_metadata.get('model_type', 'XGBoost')
+                st.caption(
+                    f"Precomputed by GitHub Actions: {generated_at} · "
+                    f"validation model: {validation_model_type}"
+                )
 
-            X_sc_eval, y_sc_eval = get_features_and_target_safety_car(safety_cars)
-            mask_sc = y_sc_eval.notnull() & np.isfinite(y_sc_eval)
-            X_sc_eval, y_sc_eval = X_sc_eval[mask_sc], y_sc_eval[mask_sc]
-            if X_sc_eval.shape[0] == 0:
-                st.warning("No safety-car data for CV evaluation; skipping safety car CV metrics.")
-            else:
-                scores_sc = cross_val_score(get_safetycar_model(CACHE_VERSION), X_sc_eval, y_sc_eval, cv=5, scoring='roc_auc')
-                st.write(f"Safety Car Model - Cross-validated ROC AUC (unique rows): {scores_sc.mean():.3f} (± {scores_sc.std():.3f})")
+                st.write("### Model Evaluation Metrics (Cross-Validation)")
+                position_cv = historical_validation.get('position_cv', {})
+                if position_cv:
+                    st.write(
+                        "Final Position Model - Cross-validated MSE: "
+                        f"{position_cv.get('mse_mean', float('nan')):.3f} "
+                        f"(± {position_cv.get('mse_std', float('nan')):.3f})"
+                    )
 
-            # Model Accuracy for All Races
-            st.write("### Model Accuracy Across All Races")
-            X_all, y_all = get_features_and_target(data)
-            X_train_all, X_test_all, y_train_all, y_test_all = train_test_split(X_all, y_all, test_size=0.2, random_state=42)
+                dnf_validation = historical_validation.get('dnf_validation', {})
+                if dnf_validation:
+                    if dnf_validation.get('test_mae') is not None:
+                        st.write(
+                            "Mean Absolute Error (MAE) for DNF Probability (test set): "
+                            f"{dnf_validation['test_mae']:.3f}"
+                        )
+                    st.write(
+                        "DNF Model - Cross-validated ROC AUC: "
+                        f"{dnf_validation.get('roc_auc_mean', float('nan')):.3f} "
+                        f"(± {dnf_validation.get('roc_auc_std', float('nan')):.3f})"
+                    )
 
-            # Use the training preprocessor from session state (ensures feature consistency)
-            preprocessor_all = st.session_state.get('training_preprocessor')
-            if preprocessor_all is None:
-                st.error("Training preprocessor not found. Please train a model first.")
-            else:
-                # Align X_test_all columns to match what the preprocessor was fit on
-                # (handles cases where columns were dropped as all-NaN since training)
-                expected_cols = preprocessor_all.feature_names_in_ if hasattr(preprocessor_all, 'feature_names_in_') else None
-                if expected_cols is not None:
-                    missing_cols = [c for c in expected_cols if c not in X_test_all.columns]
-                    for c in missing_cols:
-                        X_test_all[c] = np.nan
-                    X_test_all = X_test_all[expected_cols]
-                X_test_prep_all = _prep_as_df(preprocessor_all.transform(X_test_all), preprocessor_all)
-                
-                # Predict based on model type
-                if isinstance(model, xgb.Booster):  # XGBoost
-                    y_pred_all = model.predict(xgb.DMatrix(X_test_prep_all))
-                else:  # LightGBM, CatBoost, sklearn models
-                    y_pred_all = model.predict(X_test_prep_all)
+                safety_car_validation = historical_validation.get('safety_car_validation', {})
+                if safety_car_validation:
+                    st.write(
+                        "Safety Car Model - Cross-validated ROC AUC (unique rows): "
+                        f"{safety_car_validation.get('roc_auc_mean', float('nan')):.3f} "
+                        f"(± {safety_car_validation.get('roc_auc_std', float('nan')):.3f})"
+                    )
 
-            results_df_all = X_test_all.copy()
-            results_df_all['ActualFinalPosition'] = y_test_all.values
-            results_df_all['PredictedFinalPosition'] = y_pred_all
-            results_df_all['Error'] = results_df_all['ActualFinalPosition'] - results_df_all['PredictedFinalPosition']
-
-            results_df_pos = pd.DataFrame({
-                'Actual': y_test_all.values,
-                'Predicted': y_pred_all
-            })
-
-            podium_actual_hist = results_df_pos[results_df_pos['Actual'] <= 3]
-            points_actual_hist = results_df_pos[results_df_pos['Actual'] <= 10]
-            winners_actual_hist = results_df_pos[results_df_pos['Actual'] == 1]
-
-            if len(podium_actual_hist) > 0:
-                podium_mae_hist = mean_absolute_error(podium_actual_hist['Actual'], podium_actual_hist['Predicted'])
-                
-            if len(winners_actual_hist) > 0:
-                winner_mae_hist = mean_absolute_error(winners_actual_hist['Actual'], winners_actual_hist['Predicted'])
-
-            if len(points_actual_hist) > 0:
-                points_mae_hist = mean_absolute_error(points_actual_hist['Actual'], points_actual_hist['Predicted'])
-
-            # Render a compact metrics + position MAE table
-            metrics = {
-                'Mean Squared Error': mse,
-                'R^2 Score': r2,
-                'Mean Absolute Error': mae,
-                'Mean Error': mean_err
-            }
-            position_mae_hist = {}
-            if 'podium_mae_hist' in locals():
-                position_mae_hist['Podium (1-3)'] = podium_mae_hist
-            if 'winner_mae_hist' in locals():
-                position_mae_hist['Winners'] = winner_mae_hist
-            if 'points_mae_hist' in locals():
-                position_mae_hist['Points (1-10)'] = points_mae_hist
-
-            display_model_performance(metrics=metrics, position_mae=position_mae_hist if position_mae_hist else None)
-
-            st.dataframe(
-                results_df_all[['constructorName', 'resultsDriverName', 'ActualFinalPosition', 'PredictedFinalPosition', 'Error']].sort_values(by=['ActualFinalPosition']),
-                hide_index=True,
-                width=1000,
-                column_config={
-                    'constructorName': st.column_config.TextColumn("Constructor"),
-                    'resultsDriverName': st.column_config.TextColumn("Driver"),
-                    'ActualFinalPosition': st.column_config.NumberColumn("Actual", format="%d"),
-                    'PredictedFinalPosition': st.column_config.NumberColumn("Predicted", format="%.2f"),
-                    'Error': st.column_config.NumberColumn("Error", format="%.2f"),
+                st.write("### Model Accuracy Across All Races")
+                holdout = historical_validation.get('holdout', {})
+                holdout_metrics = holdout.get('metrics', {})
+                metrics = {
+                    'Mean Squared Error': holdout_metrics.get('mse'),
+                    'R^2 Score': holdout_metrics.get('r2'),
+                    'Mean Absolute Error': holdout_metrics.get('mae'),
+                    'Mean Error': holdout_metrics.get('mean_error'),
                 }
-            )
+                metrics = {label: value for label, value in metrics.items() if value is not None}
+                position_mae_hist = holdout.get('position_mae', {})
+                if metrics:
+                    display_model_performance(
+                        metrics=metrics,
+                        position_mae=position_mae_hist if position_mae_hist else None,
+                    )
 
-            st.subheader("Actual vs Predicted Final Position (All Races)")
-            st.scatter_chart(results_df_all, x='ActualFinalPosition', y='PredictedFinalPosition', width='stretch')
+                results_df_all = pd.DataFrame(holdout.get('rows', []))
+                expected_result_columns = [
+                    'constructorName',
+                    'resultsDriverName',
+                    'ActualFinalPosition',
+                    'PredictedFinalPosition',
+                    'Error',
+                ]
+                if not results_df_all.empty and set(expected_result_columns).issubset(results_df_all.columns):
+                    results_df_all = results_df_all.sort_values(by=['ActualFinalPosition'])
+                    st.dataframe(
+                        results_df_all[expected_result_columns],
+                        hide_index=True,
+                        width=1000,
+                        column_config={
+                            'constructorName': st.column_config.TextColumn("Constructor"),
+                            'resultsDriverName': st.column_config.TextColumn("Driver"),
+                            'ActualFinalPosition': st.column_config.NumberColumn("Actual", format="%d"),
+                            'PredictedFinalPosition': st.column_config.NumberColumn("Predicted", format="%.2f"),
+                            'Error': st.column_config.NumberColumn("Error", format="%.2f"),
+                        },
+                    )
+
+                    st.subheader("Actual vs Predicted Final Position (All Races)")
+                    st.scatter_chart(
+                        results_df_all,
+                        x='ActualFinalPosition',
+                        y='PredictedFinalPosition',
+                        width='stretch',
+                    )
         
         with tab_debug:
             st.subheader("Debug & Experiments")

--- a/scripts/check_features.py
+++ b/scripts/check_features.py
@@ -17,8 +17,8 @@ from raceAnalysis import (
 print("Loading data...")
 # include CSV modification time so caching invalidates when file updates
 from raceAnalysis import DATA_DIR
-csv_mtime = os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
-data, pitStops = load_data(1000, None, csv_mtime)  # Load smaller dataset for testing
+from raceAnalysis import get_data_fingerprint
+data, pitStops = load_data(1000, None, get_data_fingerprint()['data_sha256'])  # Load smaller dataset for testing
 
 print(f"Original data shape: {data.shape}")
 print(f"Original columns with team info: {[col for col in data.columns if 'constructor' in col.lower() or 'driver' in col.lower()][:10]}")

--- a/scripts/check_streamlit_deprecations.py
+++ b/scripts/check_streamlit_deprecations.py
@@ -1,0 +1,54 @@
+"""Fail CI when removed Streamlit keyword arguments are used in Python code."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {".git", ".venv", ".venv-mac", "__pycache__"}
+FORBIDDEN_KEYWORDS = {"use_container_width"}
+
+
+def python_files() -> list[Path]:
+    return [
+        path
+        for path in REPO_ROOT.rglob("*.py")
+        if not SKIP_DIRS.intersection(path.relative_to(REPO_ROOT).parts)
+    ]
+
+
+def main() -> int:
+    violations: list[str] = []
+
+    for path in python_files():
+        source = path.read_text(encoding="utf-8-sig")
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError as exc:
+            violations.append(f"{path.relative_to(REPO_ROOT)}:{exc.lineno}: syntax error: {exc.msg}")
+            continue
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            for keyword in node.keywords:
+                if keyword.arg in FORBIDDEN_KEYWORDS:
+                    violations.append(
+                        f"{path.relative_to(REPO_ROOT)}:{keyword.value.lineno}: "
+                        f"deprecated Streamlit keyword {keyword.arg!r}"
+                    )
+
+    if violations:
+        print("Streamlit API compatibility check failed:")
+        for violation in violations:
+            print(f"- {violation}")
+        return 1
+
+    print("Streamlit API compatibility check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/precompute/historical_validation.py
+++ b/scripts/precompute/historical_validation.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Precompute cross-validation metrics and holdout predictions for Streamlit."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+os.environ["STREAMLIT_SERVER_HEADLESS"] = "1"
+os.environ["STREAMLIT_LOG_LEVEL"] = "error"
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+from sklearn.model_selection import cross_val_score, train_test_split
+from sklearn.pipeline import Pipeline
+from xgboost import XGBRegressor
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+import json_helpers
+
+
+def _clean_target(X: pd.DataFrame, y: pd.Series) -> tuple[pd.DataFrame, pd.Series]:
+    valid = y.notnull() & np.isfinite(y)
+    return X.loc[valid], y.loc[valid]
+
+
+def _position_mae(y_true: pd.Series, y_pred: np.ndarray) -> dict[str, float]:
+    values = pd.DataFrame({"actual": y_true.to_numpy(), "predicted": y_pred})
+    groups = {
+        "Podium (1-3)": values["actual"] <= 3,
+        "Winners": values["actual"] == 1,
+        "Points (1-10)": values["actual"] <= 10,
+    }
+    return {
+        label: float(mean_absolute_error(values.loc[mask, "actual"], values.loc[mask, "predicted"]))
+        for label, mask in groups.items()
+        if mask.any()
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--output",
+        default="data_files/precomputed/historical_validation.json",
+    )
+    args = parser.parse_args()
+
+    from raceAnalysis import (
+        CACHE_VERSION,
+        _build_advanced_preprocessor,
+        data,
+        get_data_fingerprint,
+        get_dnf_model,
+        get_features_and_target,
+        get_features_and_target_dnf,
+        get_features_and_target_safety_car,
+        get_preprocessor_position,
+        get_safetycar_model,
+        safety_cars,
+    )
+
+    for logger_name in (
+        "streamlit",
+        "streamlit.runtime",
+        "streamlit.runtime.scriptrunner_utils.script_run_context",
+    ):
+        logging.getLogger(logger_name).setLevel(logging.ERROR)
+
+    print("Computing position-model cross-validation...")
+    X_position, y_position = _clean_target(*get_features_and_target(data))
+    position_pipeline = Pipeline(
+        [
+            ("pre", get_preprocessor_position(X_position)),
+            (
+                "model",
+                XGBRegressor(
+                    n_estimators=100,
+                    max_depth=4,
+                    n_jobs=-1,
+                    tree_method="hist",
+                    random_state=42,
+                ),
+            ),
+        ]
+    )
+    position_scores = cross_val_score(
+        position_pipeline,
+        X_position,
+        y_position,
+        cv=5,
+        scoring="neg_mean_squared_error",
+    )
+
+    print("Computing DNF validation...")
+    X_dnf, y_dnf = _clean_target(*get_features_and_target_dnf(data))
+    dnf_model = get_dnf_model(CACHE_VERSION)
+    _, X_test_dnf, _, y_test_dnf = train_test_split(
+        X_dnf,
+        y_dnf,
+        test_size=0.2,
+        random_state=42,
+    )
+    dnf_test_probabilities = dnf_model.predict_proba(X_test_dnf)[:, 1]
+    dnf_scores = cross_val_score(dnf_model, X_dnf, y_dnf, cv=5, scoring="roc_auc")
+
+    print("Computing safety-car validation...")
+    X_safety, y_safety = _clean_target(
+        *get_features_and_target_safety_car(safety_cars)
+    )
+    safety_model = get_safetycar_model(CACHE_VERSION)
+    safety_scores = cross_val_score(
+        safety_model,
+        X_safety,
+        y_safety,
+        cv=5,
+        scoring="roc_auc",
+    )
+
+    print("Generating position-model holdout predictions...")
+    X_train, X_test, y_train, y_test = train_test_split(
+        X_position,
+        y_position,
+        test_size=0.2,
+        random_state=42,
+    )
+    holdout_pipeline = Pipeline(
+        [
+            ("pre", _build_advanced_preprocessor(X_position)),
+            (
+                "model",
+                XGBRegressor(
+                    n_estimators=500,
+                    learning_rate=0.05,
+                    max_depth=6,
+                    subsample=0.8,
+                    colsample_bytree=0.8,
+                    random_state=42,
+                    n_jobs=-1,
+                ),
+            ),
+        ]
+    )
+    holdout_pipeline.fit(X_train, y_train)
+    predictions = np.asarray(holdout_pipeline.predict(X_test))
+
+    source_rows = data.loc[y_test.index]
+    holdout_rows = pd.DataFrame(
+        {
+            "constructorName": source_rows["constructorName"].astype(str),
+            "resultsDriverName": source_rows["resultsDriverName"].astype(str),
+            "ActualFinalPosition": y_test.to_numpy(),
+            "PredictedFinalPosition": predictions,
+        }
+    )
+    holdout_rows["Error"] = (
+        holdout_rows["ActualFinalPosition"]
+        - holdout_rows["PredictedFinalPosition"]
+    )
+
+    output = {
+        "metadata": {
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "model_type": "XGBoost",
+            "folds": 5,
+            "data_fingerprint": get_data_fingerprint(),
+        },
+        "position_cv": {
+            "mse_mean": float(-position_scores.mean()),
+            "mse_std": float(position_scores.std()),
+            "sample_count": int(len(y_position)),
+        },
+        "dnf_validation": {
+            "test_mae": float(mean_absolute_error(y_test_dnf, dnf_test_probabilities)),
+            "roc_auc_mean": float(dnf_scores.mean()),
+            "roc_auc_std": float(dnf_scores.std()),
+            "sample_count": int(len(y_dnf)),
+        },
+        "safety_car_validation": {
+            "roc_auc_mean": float(safety_scores.mean()),
+            "roc_auc_std": float(safety_scores.std()),
+            "sample_count": int(len(y_safety)),
+        },
+        "holdout": {
+            "metrics": {
+                "mse": float(mean_squared_error(y_test, predictions)),
+                "r2": float(r2_score(y_test, predictions)),
+                "mae": float(mean_absolute_error(y_test, predictions)),
+                "mean_error": float(np.mean(y_test.to_numpy() - predictions)),
+            },
+            "position_mae": _position_mae(y_test, predictions),
+            "rows": holdout_rows.to_dict(orient="records"),
+        },
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    json_helpers.safe_dump(output, output_path, indent=2)
+    print(f"Historical validation saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/precompute/monthly_hpo.py
+++ b/scripts/precompute/monthly_hpo.py
@@ -58,6 +58,7 @@ def load_data():
     # Lazy import so raceAnalysis Streamlit side-effects run only here
     from raceAnalysis import (  # noqa: PLC0415
         load_data as ra_load_data,
+        get_data_fingerprint,
         get_features_and_target,
         _build_advanced_preprocessor,
         CACHE_VERSION,
@@ -81,7 +82,7 @@ def load_data():
     data, _ = ra_load_data(
         10000,
         CACHE_VERSION,
-        csv_path.stat().st_mtime,
+        get_data_fingerprint()['data_sha256'],
     )
 
     X, y = get_features_and_target(data)

--- a/scripts/precompute/position_group_analysis_precompute.py
+++ b/scripts/precompute/position_group_analysis_precompute.py
@@ -169,7 +169,8 @@ def main():
         mean_err_fresh = np.mean(y_test - y_pred_fresh)
         
         model_path.parent.mkdir(parents=True, exist_ok=True)
-        model_data = {
+        from model_artifacts import build_data_fingerprint, stamp_artifact
+        model_data = stamp_artifact({
             'model': model,
             'preprocessor': preprocessor,
             'mae': mae_fresh,
@@ -179,7 +180,7 @@ def main():
             'evals_result': {},
             'timestamp': datetime.now().isoformat(),
             'cache_version': 'v3.3'
-        }
+        }, build_data_fingerprint(Path('data_files/f1ForAnalysis.csv')))
         try:
             with open(model_path, 'wb') as f:
                 pickle.dump(model_data, f)

--- a/scripts/precompute/train_catboost.py
+++ b/scripts/precompute/train_catboost.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # helper for robust json serialization of numpy/pandas scalars used by precompute scripts
 import json_helpers
+from model_artifacts import build_data_fingerprint, stamp_artifact
 
 DATA_DIR = 'data_files/'
 
@@ -50,10 +51,11 @@ def train_catboost_models():
     logging.getLogger('streamlit.runtime.state.session_state_proxy').setLevel(logging.ERROR)
     
     print(f"\nLoading data (CACHE_VERSION={CACHE_VERSION})...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
     
     # Apply column renaming
@@ -75,7 +77,7 @@ def train_catboost_models():
         model_type="CatBoost"
     )
     
-    position_artifact = {
+    position_artifact = stamp_artifact({
         'model': model,
         'preprocessor': preprocessor,
         'mse': mse,
@@ -86,14 +88,14 @@ def train_catboost_models():
         'cache_version': CACHE_VERSION,
         'model_type': 'CatBoost',
         'trained_at': datetime.now().isoformat()
-    }
+    }, analysis_fingerprint)
     
     with open(output_dir / 'position_model.pkl', 'wb') as f:
         pickle.dump(position_artifact, f)
     print(f"[OK] Position model saved (MAE: {mae:.4f})")
     
     # Save metadata
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at': datetime.now().isoformat(),
         'model_type': 'CatBoost',
@@ -105,7 +107,7 @@ def train_catboost_models():
                 'r2': float(r2)
             }
         }
-    }
+    }, analysis_fingerprint)
     
     json_helpers.safe_dump(metadata, output_dir / 'metadata.json', indent=2)
     

--- a/scripts/precompute/train_ensemble.py
+++ b/scripts/precompute/train_ensemble.py
@@ -29,6 +29,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # helper for robust json serialization of numpy/pandas scalars used by precompute scripts
 import json_helpers
+from model_artifacts import build_data_fingerprint, stamp_artifact
 
 DATA_DIR = 'data_files/'
 
@@ -52,10 +53,11 @@ def train_ensemble_model():
     )
     
     print(f"\nLoading data (CACHE_VERSION={CACHE_VERSION})...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
     
     # Apply column renaming
@@ -77,7 +79,7 @@ def train_ensemble_model():
         model_type="Ensemble (XGBoost + LightGBM + CatBoost)"
     )
     
-    position_artifact = {
+    position_artifact = stamp_artifact({
         'model': model,
         'preprocessor': preprocessor,
         'mse': mse,
@@ -88,14 +90,14 @@ def train_ensemble_model():
         'cache_version': CACHE_VERSION,
         'model_type': 'Ensemble',
         'trained_at': datetime.now().isoformat()
-    }
+    }, analysis_fingerprint)
     
     with open(output_dir / 'position_model.pkl', 'wb') as f:
         pickle.dump(position_artifact, f)
     print(f"[OK] Ensemble model saved (MAE: {mae:.4f})")
     
     # Save metadata
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at': datetime.now().isoformat(),
         'model_type': 'Ensemble',
@@ -107,7 +109,7 @@ def train_ensemble_model():
                 'r2': float(r2)
             }
         }
-    }
+    }, analysis_fingerprint)
     
     json_helpers.safe_dump(metadata, output_dir / 'metadata.json', indent=2)
     

--- a/scripts/precompute/train_lightgbm.py
+++ b/scripts/precompute/train_lightgbm.py
@@ -24,6 +24,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # helper for robust json serialization of numpy/pandas scalars used by precompute scripts
 import json_helpers
+from model_artifacts import build_data_fingerprint, stamp_artifact
 
 DATA_DIR = 'data_files/'
 
@@ -50,10 +51,11 @@ def train_lightgbm_models():
     logging.getLogger('streamlit.runtime.state.session_state_proxy').setLevel(logging.ERROR)
     
     print(f"\nLoading data (CACHE_VERSION={CACHE_VERSION})...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
     
     # Apply column renaming
@@ -75,7 +77,7 @@ def train_lightgbm_models():
         model_type="LightGBM"
     )
     
-    position_artifact = {
+    position_artifact = stamp_artifact({
         'model': model,
         'preprocessor': preprocessor,
         'mse': mse,
@@ -86,14 +88,14 @@ def train_lightgbm_models():
         'cache_version': CACHE_VERSION,
         'model_type': 'LightGBM',
         'trained_at': datetime.now().isoformat()
-    }
+    }, analysis_fingerprint)
     
     with open(output_dir / 'position_model.pkl', 'wb') as f:
         pickle.dump(position_artifact, f)
     print(f"[OK] Position model saved (MAE: {mae:.4f})")
     
     # Save metadata
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at': datetime.now().isoformat(),
         'model_type': 'LightGBM',
@@ -105,7 +107,7 @@ def train_lightgbm_models():
                 'r2': float(r2)
             }
         }
-    }
+    }, analysis_fingerprint)
     
     json_helpers.safe_dump(metadata, output_dir / 'metadata.json', indent=2)
     

--- a/scripts/precompute/train_position_group.py
+++ b/scripts/precompute/train_position_group.py
@@ -32,6 +32,7 @@ DATA_DIR = 'data_files/'
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import json_helpers
+from model_artifacts import build_data_fingerprint, stamp_artifact
 
 
 def train_position_group():
@@ -53,10 +54,11 @@ def train_position_group():
     logging.getLogger('streamlit.runtime.caching.cache_data_api').setLevel(logging.ERROR)
 
     print(f"\nLoading data (CACHE_VERSION={CACHE_VERSION})...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
 
     # Apply standard column renames (matches other train scripts)
@@ -86,7 +88,7 @@ def train_position_group():
         model_type="Position Group",
     )
 
-    artifact = {
+    artifact = stamp_artifact({
         'model':        model,
         'preprocessor': preprocessor,
         'mse':          float(mse),
@@ -97,14 +99,14 @@ def train_position_group():
         'cache_version': CACHE_VERSION,
         'model_type':   'Position Group',
         'trained_at':   datetime.now().isoformat(),
-    }
+    }, analysis_fingerprint)
 
     pkl_path = output_dir / 'position_model.pkl'
     with open(pkl_path, 'wb') as f:
         pickle.dump(artifact, f)
     print(f"[OK] Position Group model saved → {pkl_path}  (OOF MAE: {mae:.4f})")
 
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at':    datetime.now().isoformat(),
         'model_type':    'Position Group',
@@ -112,7 +114,7 @@ def train_position_group():
         'models': {
             'position': {'mae': float(mae), 'mse': float(mse), 'r2': float(r2)},
         },
-    }
+    }, analysis_fingerprint)
     json_helpers.safe_dump(metadata, output_dir / 'metadata.json', indent=2)
 
     print("\n" + "=" * 60)

--- a/scripts/precompute/train_track_weighted.py
+++ b/scripts/precompute/train_track_weighted.py
@@ -23,6 +23,7 @@ warnings.filterwarnings("ignore")
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 import json_helpers
+from model_artifacts import build_data_fingerprint, stamp_artifact
 
 DATA_DIR = 'data_files/'
 
@@ -50,10 +51,11 @@ def train_track_weighted_models():
     logging.getLogger('streamlit.runtime.state.session_state_proxy').setLevel(logging.ERROR)
 
     print(f"\nLoading data (CACHE_VERSION={CACHE_VERSION})...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
 
     # Apply column renaming logic (mirrors other train_*.py scripts)
@@ -88,7 +90,7 @@ def train_track_weighted_models():
         print("[ERROR] Training returned None — LightGBM may not be available in this environment.")
         return None
 
-    position_artifact = {
+    position_artifact = stamp_artifact({
         'model': model,
         'preprocessor': preprocessor,
         'mse': float(mse) if mse is not None else None,
@@ -99,13 +101,13 @@ def train_track_weighted_models():
         'cache_version': CACHE_VERSION,
         'model_type': 'Track-Weighted Ensemble',
         'trained_at': datetime.now().isoformat(),
-    }
+    }, analysis_fingerprint)
 
     with open(output_dir / 'position_model.pkl', 'wb') as f:
         pickle.dump(position_artifact, f)
     print(f"[OK] Position model saved (MAE: {mae:.4f})")
 
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at': datetime.now().isoformat(),
         'model_type': 'Track-Weighted Ensemble',
@@ -117,7 +119,7 @@ def train_track_weighted_models():
                 'r2': float(r2) if r2 is not None else None,
             }
         }
-    }
+    }, analysis_fingerprint)
 
     json_helpers.safe_dump(metadata, output_dir / 'metadata.json', indent=2)
 

--- a/scripts/precompute/train_xgboost.py
+++ b/scripts/precompute/train_xgboost.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 # helper for robust json serialization of numpy/pandas scalars used by precompute scripts
 import json_helpers
+from model_artifacts import build_data_fingerprint, stamp_artifact
 
 def train_xgboost_models():
     """Train all XGBoost models and save to data_files/models/xgboost/"""
@@ -58,10 +59,11 @@ def train_xgboost_models():
     logging.getLogger('streamlit.runtime.state.session_state_proxy').setLevel(logging.ERROR)
     
     print(f"\nLoading data (CACHE_VERSION={CACHE_VERSION})...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(os.path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
     
     # Apply column renaming logic
@@ -94,7 +96,7 @@ def train_xgboost_models():
         model_type="XGBoost"
     )
     
-    position_artifact = {
+    position_artifact = stamp_artifact({
         'model': model,
         'preprocessor': preprocessor,
         'mse': mse,
@@ -105,7 +107,7 @@ def train_xgboost_models():
         'cache_version': CACHE_VERSION,
         'model_type': 'XGBoost',
         'trained_at': datetime.now().isoformat()
-    }
+    }, analysis_fingerprint)
     
     with open(output_dir / 'position_model.pkl', 'wb') as f:
         pickle.dump(position_artifact, f)
@@ -118,11 +120,11 @@ def train_xgboost_models():
     
     dnf_model = train_and_evaluate_dnf_model(data, CACHE_VERSION)
     
-    dnf_artifact = {
+    dnf_artifact = stamp_artifact({
         'model': dnf_model,
         'cache_version': CACHE_VERSION,
         'trained_at': datetime.now().isoformat()
-    }
+    }, analysis_fingerprint)
     
     with open(output_dir / 'dnf_model.pkl', 'wb') as f:
         pickle.dump(dnf_artifact, f)
@@ -135,14 +137,15 @@ def train_xgboost_models():
     
     safety_cars_file = Path('data_files/f1SafetyCarFeatures.csv')
     if safety_cars_file.exists():
+        safetycar_fingerprint = build_data_fingerprint(safety_cars_file)
         safety_cars = pd.read_csv(safety_cars_file, sep='\t')
         safetycar_model = train_and_evaluate_safetycar_model(safety_cars, CACHE_VERSION)
         
-        safetycar_artifact = {
+        safetycar_artifact = stamp_artifact({
             'model': safetycar_model,
             'cache_version': CACHE_VERSION,
             'trained_at': datetime.now().isoformat()
-        }
+        }, safetycar_fingerprint)
         
         with open(output_dir / 'safetycar_model.pkl', 'wb') as f:
             pickle.dump(safetycar_artifact, f)
@@ -151,7 +154,7 @@ def train_xgboost_models():
         print("[WARN] Safety car data not found - skipping")
     
     # Save metadata
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at': datetime.now().isoformat(),
         'model_type': 'XGBoost',
@@ -165,7 +168,7 @@ def train_xgboost_models():
             'dnf': {'trained': True},
             'safetycar': {'trained': safety_cars_file.exists()}
         }
-    }
+    }, analysis_fingerprint)
     
     json_helpers.safe_dump(metadata, output_dir / 'metadata.json', indent=2)
     

--- a/scripts/print_mae.py
+++ b/scripts/print_mae.py
@@ -1,6 +1,11 @@
 import os, sys
 # ensure project root is on sys.path so we can import raceAnalysis
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from raceAnalysis import get_trained_model, DATA_DIR, CACHE_VERSION
-model,mse,r2,mae,mean_err,evals_result,preprocessor = get_trained_model(20, CACHE_VERSION, os.path.getmtime(os.path.join(DATA_DIR,'f1ForAnalysis.csv')),'Position Group')
+from raceAnalysis import get_trained_model, get_data_fingerprint, CACHE_VERSION
+model,mse,r2,mae,mean_err,evals_result,preprocessor = get_trained_model(
+    20,
+    CACHE_VERSION,
+    get_data_fingerprint()['data_sha256'],
+    model_type='Position Group',
+)
 print('mae', mae)

--- a/scripts/train_and_save_models.py
+++ b/scripts/train_and_save_models.py
@@ -51,6 +51,8 @@ warnings.filterwarnings("ignore", message=".*No runtime found, using MemoryCache
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
+from model_artifacts import build_data_fingerprint, stamp_artifact
+
 # Add parent directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
@@ -79,10 +81,11 @@ def train_all_models():
     )
     
     print(f"Loading data with CACHE_VERSION={CACHE_VERSION}...")
+    analysis_fingerprint = build_data_fingerprint(Path(DATA_DIR) / 'f1ForAnalysis.csv')
     data, _ = load_data(
         10000,
         CACHE_VERSION,
-        os.path.getmtime(path.join(DATA_DIR, 'f1ForAnalysis.csv'))
+        analysis_fingerprint['data_sha256']
     )
     
     # Apply the same column renaming logic as in raceAnalysis.py
@@ -125,7 +128,7 @@ def train_all_models():
     )
     
     # Save model and metrics
-    model_artifact = {
+    model_artifact = stamp_artifact({
         'model': model,
         'preprocessor': preprocessor,
         'mse': mse,
@@ -135,7 +138,7 @@ def train_all_models():
         'evals_result': evals_result,
         'cache_version': CACHE_VERSION,
         'model_type': 'XGBoost'
-    }
+    }, analysis_fingerprint)
     
     with open(models_dir / 'position_model.pkl', 'wb') as f:
         pickle.dump(model_artifact, f)
@@ -146,7 +149,10 @@ def train_all_models():
     dnf_model = train_and_evaluate_dnf_model(data, CACHE_VERSION)
     
     with open(models_dir / 'dnf_model.pkl', 'wb') as f:
-        pickle.dump({'model': dnf_model, 'cache_version': CACHE_VERSION}, f)
+        pickle.dump(stamp_artifact(
+            {'model': dnf_model, 'cache_version': CACHE_VERSION},
+            analysis_fingerprint,
+        ), f)
     print("   [OK] Saved DNF model")
     
     # Train safety car prediction model
@@ -154,17 +160,21 @@ def train_all_models():
         print("\n3. Training safety car prediction model...")
         safetycar_model = train_and_evaluate_safetycar_model(safety_cars, CACHE_VERSION)
         
+        safetycar_fingerprint = build_data_fingerprint(safety_cars_file)
         with open(models_dir / 'safetycar_model.pkl', 'wb') as f:
-            pickle.dump({'model': safetycar_model, 'cache_version': CACHE_VERSION}, f)
+            pickle.dump(stamp_artifact(
+                {'model': safetycar_model, 'cache_version': CACHE_VERSION},
+                safetycar_fingerprint,
+            ), f)
         print("   [OK] Saved safety car model")
     
     # Save metadata
-    metadata = {
+    metadata = stamp_artifact({
         'cache_version': CACHE_VERSION,
         'trained_at': pd.Timestamp.now().isoformat(),
         'data_rows': len(data),
         'models': ['position_model', 'dnf_model', 'safetycar_model' if safety_cars is not None else None]
-    }
+    }, analysis_fingerprint)
     
     with open(models_dir / 'metadata.pkl', 'wb') as f:
         pickle.dump(metadata, f)

--- a/tests/test_model_artifacts.py
+++ b/tests/test_model_artifacts.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from model_artifacts import (
+    artifact_matches_fingerprint,
+    build_data_fingerprint,
+    stamp_artifact,
+)
+
+
+class ModelArtifactFingerprintTests(unittest.TestCase):
+    def test_fingerprint_is_content_based(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            first = Path(directory, "first.csv")
+            second = Path(directory, "second.csv")
+            first.write_bytes(b"same-content\n")
+            second.write_bytes(b"same-content\n")
+
+            first_fingerprint = build_data_fingerprint(first)
+            second_fingerprint = build_data_fingerprint(second)
+
+            self.assertEqual(first_fingerprint["data_sha256"], second_fingerprint["data_sha256"])
+
+    def test_stamped_artifact_matches_its_dataset(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            data_path = Path(directory, "f1ForAnalysis.csv")
+            data_path.write_bytes(b"race-data\n")
+            fingerprint = build_data_fingerprint(data_path)
+            artifact: dict[str, object] = {"model": "placeholder"}
+
+            stamp_artifact(artifact, fingerprint)
+
+            self.assertTrue(artifact_matches_fingerprint(artifact, fingerprint))
+
+    def test_changed_content_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            data_path = Path(directory, "f1ForAnalysis.csv")
+            data_path.write_bytes(b"old-data\n")
+            artifact: dict[str, object] = {}
+            stamp_artifact(artifact, build_data_fingerprint(data_path))
+            data_path.write_bytes(b"new-data\n")
+
+            self.assertFalse(
+                artifact_matches_fingerprint(artifact, build_data_fingerprint(data_path))
+            )
+
+    def test_legacy_artifact_has_unknown_status(self) -> None:
+        fingerprint = {
+            "data_file": "f1ForAnalysis.csv",
+            "data_sha256": "a" * 64,
+            "data_size": 1,
+            "fingerprint_algorithm": "sha256",
+        }
+        self.assertIsNone(artifact_matches_fingerprint({}, fingerprint))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_runtime_model_policy.py
+++ b/tests/test_runtime_model_policy.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNTIME_PATH = REPO_ROOT / "raceAnalysis.py"
+
+
+def function_nodes(tree: ast.AST) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def called_names(node: ast.AST) -> set[str]:
+    names: set[str] = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        if isinstance(child.func, ast.Name):
+            names.add(child.func.id)
+        elif isinstance(child.func, ast.Attribute):
+            names.add(child.func.attr)
+    return names
+
+
+def with_blocks_for_name(tree: ast.AST, context_name: str) -> list[ast.With]:
+    matches: list[ast.With] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.With):
+            continue
+        if any(
+            isinstance(item.context_expr, ast.Name)
+            and item.context_expr.id == context_name
+            for item in node.items
+        ):
+            matches.append(node)
+    return matches
+
+
+class RuntimeModelPolicyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tree = ast.parse(RUNTIME_PATH.read_text(encoding="utf-8-sig"))
+        cls.functions = function_nodes(cls.tree)
+
+    def test_request_model_getters_never_call_training_functions(self) -> None:
+        forbidden = {
+            "train_and_evaluate_model",
+            "train_and_evaluate_dnf_model",
+            "train_and_evaluate_safetycar_model",
+        }
+        for function_name in ("get_trained_model", "get_dnf_model", "get_safetycar_model"):
+            with self.subTest(function=function_name):
+                self.assertTrue(
+                    forbidden.isdisjoint(called_names(self.functions[function_name])),
+                    f"{function_name} must load workflow artifacts, not train models",
+                )
+
+    def test_model_loader_uses_shared_resource_cache(self) -> None:
+        loader = self.functions["_load_pretrained_model_resource"]
+        decorators = [ast.unparse(decorator) for decorator in loader.decorator_list]
+        self.assertTrue(any("st.cache_resource" in decorator for decorator in decorators))
+        self.assertTrue(any("max_entries=8" in decorator for decorator in decorators))
+
+    def test_main_dataframe_cache_is_bounded(self) -> None:
+        loader = self.functions["load_data"]
+        decorators = [ast.unparse(decorator) for decorator in loader.decorator_list]
+        self.assertTrue(any("st.cache_data" in decorator for decorator in decorators))
+        self.assertTrue(any("max_entries=1" in decorator for decorator in decorators))
+
+    def test_diagnostic_tabs_do_not_run_training_or_validation(self) -> None:
+        forbidden = {"fit", "fit_transform", "permutation_importance", "cross_val_score"}
+        for tab_name in ("tab_feat", "tab_hist"):
+            blocks = with_blocks_for_name(self.tree, tab_name)
+            self.assertEqual(len(blocks), 1, f"Expected one {tab_name} render block")
+            self.assertTrue(
+                forbidden.isdisjoint(called_names(blocks[0])),
+                f"{tab_name} must render workflow artifacts instead of computing diagnostics",
+            )
+
+    def test_diagnostic_artifact_loaders_are_bounded(self) -> None:
+        for loader_name in (
+            "load_precomputed_permutation",
+            "load_precomputed_historical_validation",
+        ):
+            loader = self.functions[loader_name]
+            decorators = [ast.unparse(decorator) for decorator in loader.decorator_list]
+            self.assertTrue(any("st.cache_data" in decorator for decorator in decorators))
+            self.assertTrue(any("max_entries=1" in decorator for decorator in decorators))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Replaces deprecated use_container_width usage with the supported width API and adds a compatibility check to prevent regressions.
Prevents Streamlit requests from training models when workflow-generated artifacts are available.
Uses bounded data caches and shared resource caches to reduce memory growth across sessions and reruns.
Adds content fingerprints to model artifacts so cached models are invalidated only when underlying data changes.
Moves permutation importance and historical cross-validation out of the live application and into GitHub Actions.
Adds a precomputed historical-validation artifact containing cross-validation metrics and holdout predictions.
Fixes the permutation-importance schema mapping so the UI displays the existing workflow output correctly.
Extends the Feature Selection Suite workflow to refresh and commit historical-validation results.
Adds regression tests covering artifact fingerprints, cache limits, model-loading policy, and prevention of live diagnostic training.
Reduces the measured warmed Streamlit rerun from approximately 7 seconds to approximately 4.4 seconds while preserving preloaded data and model responsiveness.
Addresses the Streamlit Community Cloud memory-limit incident by eliminating repeated model loading, training, and unbounded cache accumulation.
Validation
Python compilation passed.
9 unit tests passed.
Streamlit API compatibility check passed.
GitHub Actions workflow YAML validation passed.
Streamlit AppTest completed with zero exceptions.
Playwright validation completed with zero browser-console errors and zero Streamlit exceptions.